### PR TITLE
pin Xcode 26+ in ios/macos workflows, add App Store upload for macos

### DIFF
--- a/.eg/release/darwin/main.go
+++ b/.eg/release/darwin/main.go
@@ -38,6 +38,7 @@ func main() {
 
 	tarballapp := filepath.Join(egtarball.Path(tarballs.Retrovibed(tarinfo())), "retrovibed.app")
 	dmgpath := egenv.CacheDirectory("retrovibed.darwin.arm64.dmg")
+	pkgpath := egenv.CacheDirectory("retrovibed.darwin.arm64.pkg")
 	keychainPath := egenv.WorkspaceDirectory("apple.signing.keychain")
 	flutter := runtime.Directory(egenv.WorkingDirectory("console"))
 	shallows := runtime.Directory(egenv.WorkingDirectory("shallows"))
@@ -85,6 +86,10 @@ func main() {
 				egenv.String("", "APPLE_SIGNING_KEY"),
 				egenv.String("", "APPLE_SIGNING_CER"),
 			),
+			release.KeychainAppendPEM(
+				egenv.String("", "APPLE_INSTALLER_KEY"),
+				egenv.String("", "APPLE_INSTALLER_CER"),
+			),
 			release.AuthKey(
 				apikey,
 				egenv.String("", "RETROVIBED_APPLE_AUTH_KEY"),
@@ -101,6 +106,13 @@ func main() {
 					Environ("APPLE_API_KEY", apikey).
 					Environ("APPLE_ISSUER_ID", issuerid),
 				shell.Newf("xcrun stapler staple %s", dmgpath),
+			),
+			shell.Op(
+				shell.Newf("security unlock-keychain -p %s %s", egenv.RunID(), keychainPath),
+				shell.Newf("productbuild --component %s /Applications --sign \"3rd Party Mac Developer Installer\" --keychain %s %s", tarballapp, keychainPath, pkgpath),
+				shell.Newf("xcrun altool --upload-app --type macos -f %s --apiKey ${APPLE_API_KEY} --apiIssuer ${APPLE_ISSUER_ID}", pkgpath).
+					Environ("APPLE_API_KEY", apikey).
+					Environ("APPLE_ISSUER_ID", issuerid),
 			),
 			eggithub.Release(dmgpath),
 		),

--- a/.eg/release/signing.go
+++ b/.eg/release/signing.go
@@ -13,24 +13,33 @@ import (
 	"github.com/egdaemon/eg/runtime/wasi/shell"
 )
 
+// writeBase64File decodes a base64-encoded secret and writes it to path with 0600 perms.
+func writeBase64File(path, b64, label string) error {
+	if strings.TrimSpace(b64) == "" {
+		return fmt.Errorf("%s: missing base64 encoded value", label)
+	}
+
+	data, err := base64.URLEncoding.DecodeString(b64)
+	if err != nil {
+		return fmt.Errorf("failed to decode base64 %s: %w", label, err)
+	}
+
+	if err = os.WriteFile(path, data, 0600); err != nil {
+		return fmt.Errorf("failed to write %s to disk: %w", label, err)
+	}
+
+	return nil
+}
+
 // Keychain creates a temporary keychain and imports the provided .p12 certificate.
 func Keychain(base64key, keypassword string) eg.OpFn {
 	return func(ctx context.Context, o eg.Op) error {
-		if strings.TrimSpace(base64key) == "" {
-			return fmt.Errorf("setting up a temporary keychain requires a base64 encoded certificate")
-		}
-
 		keypath := egenv.WorkspaceDirectory("apple.p12")
 		keychainPath := egenv.WorkspaceDirectory("apple.signing.keychain")
 		intermediatepath := egenv.WorkspaceDirectory("apple.intermediate.cer")
 
-		keyp12, err := base64.URLEncoding.DecodeString(base64key)
-		if err != nil {
-			return fmt.Errorf("failed to decode base64 certificate: %w", err)
-		}
-
-		if err = os.WriteFile(keypath, keyp12, 0600); err != nil {
-			return fmt.Errorf("failed to write certificate to disk: %w", err)
+		if err := writeBase64File(keypath, base64key, "certificate"); err != nil {
+			return err
 		}
 
 		env := shell.Runtime().
@@ -57,31 +66,17 @@ func Keychain(base64key, keypassword string) eg.OpFn {
 // KeychainPEM creates a temporary keychain and imports a PEM private key and DER certificate.
 func KeychainPEM(base64key, base64cert string) eg.OpFn {
 	return func(ctx context.Context, o eg.Op) error {
-		if strings.TrimSpace(base64key) == "" || strings.TrimSpace(base64cert) == "" {
-			return fmt.Errorf("setting up a temporary keychain requires a base64 encoded key and certificate")
-		}
-
 		keypath := egenv.WorkspaceDirectory("apple.key.pem")
 		certpath := egenv.WorkspaceDirectory("apple.cert.der")
 		keychainPath := egenv.WorkspaceDirectory("apple.signing.keychain")
 		intermediatepath := egenv.WorkspaceDirectory("apple.intermediate.cer")
 
-		keydata, err := base64.URLEncoding.DecodeString(base64key)
-		if err != nil {
-			return fmt.Errorf("failed to decode base64 key: %w", err)
+		if err := writeBase64File(keypath, base64key, "key"); err != nil {
+			return err
 		}
 
-		if err = os.WriteFile(keypath, keydata, 0600); err != nil {
-			return fmt.Errorf("failed to write key to disk: %w", err)
-		}
-
-		certdata, err := base64.URLEncoding.DecodeString(base64cert)
-		if err != nil {
-			return fmt.Errorf("failed to decode base64 certificate: %w", err)
-		}
-
-		if err = os.WriteFile(certpath, certdata, 0600); err != nil {
-			return fmt.Errorf("failed to write certificate to disk: %w", err)
+		if err := writeBase64File(certpath, base64cert, "certificate"); err != nil {
+			return err
 		}
 
 		env := shell.Runtime().
@@ -106,24 +101,51 @@ func KeychainPEM(base64key, base64cert string) eg.OpFn {
 	}
 }
 
+// KeychainAppendPEM imports an additional PEM key and DER certificate into the existing signing keychain.
+func KeychainAppendPEM(base64key, base64cert string) eg.OpFn {
+	return func(ctx context.Context, o eg.Op) error {
+		keypath := egenv.WorkspaceDirectory("apple.installer.key.pem")
+		certpath := egenv.WorkspaceDirectory("apple.installer.cert.der")
+		keychainPath := egenv.WorkspaceDirectory("apple.signing.keychain")
+
+		if err := writeBase64File(keypath, base64key, "installer key"); err != nil {
+			return err
+		}
+
+		if err := writeBase64File(certpath, base64cert, "installer certificate"); err != nil {
+			return err
+		}
+
+		env := shell.Runtime().
+			Environ("APPLE_KEYCHAIN_PASSWORD", egenv.RunID()).
+			Environ("APPLE_INSTALLER_KEY_PATH", keypath).
+			Environ("APPLE_INSTALLER_CERT_PATH", certpath).
+			Environ("APPLE_KEYCHAIN_PATH", keychainPath)
+
+		return shell.Run(
+			ctx,
+			env.New("security unlock-keychain -p ${APPLE_KEYCHAIN_PASSWORD} ${APPLE_KEYCHAIN_PATH}"),
+			env.New("security import ${APPLE_INSTALLER_KEY_PATH} -A -k ${APPLE_KEYCHAIN_PATH}"),
+			env.New("security import ${APPLE_INSTALLER_CERT_PATH} -A -k ${APPLE_KEYCHAIN_PATH}"),
+			env.New("security set-key-partition-list -S apple-tool:,apple:,codesign:,productbuild:,productsign: -s -k ${APPLE_KEYCHAIN_PASSWORD} ${APPLE_KEYCHAIN_PATH}"),
+		)
+	}
+}
+
 // AuthKey writes the App Store Connect .p8 auth key to ~/.private_keys/AuthKey_<ID>.p8.
 func AuthKey(keyid, base64authkey string) eg.OpFn {
 	return func(ctx context.Context, o eg.Op) error {
-		if strings.TrimSpace(base64authkey) == "" || strings.TrimSpace(keyid) == "" {
-			return fmt.Errorf("appleAuthKey: missing credentials")
+		if strings.TrimSpace(keyid) == "" {
+			return fmt.Errorf("appleAuthKey: missing key id")
 		}
 
 		filename := egenv.EphemeralDirectory("apple.auth.key.p8")
 
-		authkeydata, err := base64.URLEncoding.DecodeString(base64authkey)
-		if err != nil {
-			return fmt.Errorf("failed to decode base64 auth key: %w", err)
+		if err := writeBase64File(filename, base64authkey, "auth key"); err != nil {
+			return err
 		}
 
 		log.Printf("Writing Auth Key to local sandbox: %s", filename)
-		if err = os.WriteFile(filename, authkeydata, 0600); err != nil {
-			return fmt.Errorf("failed to write auth key: %w", err)
-		}
 
 		return shell.Run(
 			ctx,
@@ -138,19 +160,10 @@ func AuthKey(keyid, base64authkey string) eg.OpFn {
 // ProvisioningProfile installs a mobileprovision profile for iOS builds.
 func ProvisioningProfile(base64profile string) eg.OpFn {
 	return func(ctx context.Context, o eg.Op) error {
-		if strings.TrimSpace(base64profile) == "" {
-			return fmt.Errorf("provisioning profile: missing base64 encoded profile")
-		}
-
 		profilepath := egenv.WorkspaceDirectory("apple.mobileprovision")
 
-		profiledata, err := base64.URLEncoding.DecodeString(base64profile)
-		if err != nil {
-			return fmt.Errorf("failed to decode base64 profile: %w", err)
-		}
-
-		if err = os.WriteFile(profilepath, profiledata, 0600); err != nil {
-			return fmt.Errorf("failed to write profile to disk: %w", err)
+		if err := writeBase64File(profilepath, base64profile, "provisioning profile"); err != nil {
+			return err
 		}
 
 		env := shell.Runtime().Environ("APPLE_PROFILE_PATH", profilepath)

--- a/.github/workflows/release.ios.yml
+++ b/.github/workflows/release.ios.yml
@@ -13,6 +13,11 @@ jobs:
     name: ios-build
     runs-on: macos-latest
     steps:
+      - name: Select Xcode 26+
+        uses: maxim-lobanov/setup-xcode@v1
+        with:
+          xcode-version: "^26.0"
+
       - name: Set up Homebrew
         id: set-up-homebrew
         uses: Homebrew/actions/setup-homebrew@main

--- a/.github/workflows/release.macosx.yml
+++ b/.github/workflows/release.macosx.yml
@@ -13,6 +13,11 @@ jobs:
     name: macosx-build
     runs-on: macos-latest
     steps:
+      - name: Select Xcode 26+
+        uses: maxim-lobanov/setup-xcode@v1
+        with:
+          xcode-version: "^26.0"
+
       - name: Set up Homebrew
         id: set-up-homebrew
         uses: Homebrew/actions/setup-homebrew@main
@@ -50,4 +55,4 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          eg compute baremetal -e GH_TOKEN --no-podman --secret=gcpsm://${{ secrets.GCP_PROJECT }}/apple-signing-env --secret=gcpsm://${{ secrets.GCP_PROJECT }}/apple-macos-signing-env release/darwin
+          eg compute baremetal -e GH_TOKEN --no-podman --secret=gcpsm://${{ secrets.GCP_PROJECT }}/apple-signing-env --secret=gcpsm://${{ secrets.GCP_PROJECT }}/apple-macos-signing-env --secret=gcpsm://${{ secrets.GCP_PROJECT }}/apple-macos-installer-env release/darwin


### PR DESCRIPTION
Switches the ios and macos release workflows to Xcode 26+ so builds use the iOS 26 SDK required by App Store Connect (ITMS-90725). Imports the Mac installer identity from apple-macos-installer-env, builds a signed .pkg via productbuild, and uploads it to App Store Connect mirroring the iOS altool flow. Extracts writeBase64File to dedupe secret materialization across the signing helpers.