### PR TITLE
target iPad Air 5 / iOS 26.4 sim in dev iOS pipeline

### DIFF
--- a/.eg/console/console.ios.go
+++ b/.eg/console/console.ios.go
@@ -1,7 +1,9 @@
 package console
 
 import (
+	"bytes"
 	"context"
+	"encoding/hex"
 	"os"
 	"path/filepath"
 
@@ -44,4 +46,50 @@ func BuildIOSSimulator(ctx context.Context, _ eg.Op) error {
 		ctx,
 		runtime.New("flutter build ios --debug --simulator"),
 	)
+}
+
+// RetagSimulator rewrites LC_BUILD_VERSION platform from macOS to iOS-simulator
+// across each object in a static archive at src, producing dst. Cgo c-archive
+// output from GOOS=darwin is tagged macOS; Xcode's simulator linker refuses it.
+// cmdsize is unchanged so a direct byte substitution is sufficient and avoids
+// vtool's header-pad limitations.
+func RetagSimulator(src, dst string) eg.OpFn {
+	return func(ctx context.Context, _ eg.Op) error {
+		macOS, _ := hex.DecodeString("320000001800000001000000")
+		iosSim, _ := hex.DecodeString("320000001800000007000000")
+
+		work, err := os.MkdirTemp("", "retag-sim-")
+		if err != nil {
+			return err
+		}
+		defer os.RemoveAll(work)
+
+		if err := shell.Run(ctx, shell.Newf("cd %s && ar x %s", work, src)); err != nil {
+			return err
+		}
+
+		entries, err := os.ReadDir(work)
+		if err != nil {
+			return err
+		}
+
+		for _, e := range entries {
+			if filepath.Ext(e.Name()) != ".o" {
+				continue
+			}
+			p := filepath.Join(work, e.Name())
+			data, err := os.ReadFile(p)
+			if err != nil {
+				return err
+			}
+			if !bytes.Contains(data, macOS) {
+				continue
+			}
+			if err := os.WriteFile(p, bytes.ReplaceAll(data, macOS, iosSim), 0644); err != nil {
+				return err
+			}
+		}
+
+		return shell.Run(ctx, shell.Newf("cd %s && ar rcs %s *.o", work, dst))
+	}
 }

--- a/.eg/dev/console/ios/main.go
+++ b/.eg/dev/console/ios/main.go
@@ -94,18 +94,22 @@ func main() {
 					Debug(runtime),
 				),
 			),
+			console.RetagSimulator(
+				egenv.WorkingDirectory("console", "build", "nativelib", "ios-sim-x86_64", "libretrovibed.a"),
+				egenv.WorkingDirectory("console", "ios", "libretrovibed.a"),
+			),
 			shell.Op(
-				flutter.New("mkdir -p build/vtool_fix && cd build/vtool_fix && ar x ../nativelib/ios-sim-x86_64/libretrovibed.a && for o in *.o; do xcrun vtool -set-build-version 7 16.0 16.0 -replace -output \"$o\" \"$o\" 2>/dev/null || xcrun vtool -set-build-version 7 16.0 16.0 -output \"$o\" \"$o\" 2>/dev/null || true; done && ar rcs ../../ios/libretrovibed.a *.o && cd ../.. && rm -rf build/vtool_fix"),
 				flutter.New("cp build/nativelib/ios-sim-x86_64/libretrovibed.h ios/Classes/libretrovibed.h"),
 				flutter.Newf("libtool -static -o ios/libduckdb_static.a $(find %s -name '*.a' ! -path '*/test/*')", duckdbbuild),
 				flutter.New("flutter create --org space.retrovibe --platforms=ios ."),
 				flutter.New("flutter pub get"),
 				flutter.New("cd ios && pod install"),
 				runtime.New("open -a Simulator"),
-				runtime.New("xcrun simctl boot 'iPhone 16'").Lenient(true),
+				runtime.New("xcrun simctl list devices 'iOS 26.4' | grep -q 'Retrovibed Review' || xcrun simctl create 'Retrovibed Review' com.apple.CoreSimulator.SimDeviceType.iPad-Air-5th-generation com.apple.CoreSimulator.SimRuntime.iOS-26-4"),
+				runtime.New("xcrun simctl boot 'Retrovibed Review'").Lenient(true),
 				runtime.New("xcrun simctl list devices booted").Attempts(15),
 			),
-			console.RunDev("flutter run -d iPhone"),
+			console.RunDev("flutter run -d 'Retrovibed Review'"),
 		),
 	)
 

--- a/.eg/dev/console/macos/main.go
+++ b/.eg/dev/console/macos/main.go
@@ -62,6 +62,7 @@ func main() {
 				),
 			),
 			shell.Op(
+				flutter.New("flutter create --org space.retrovibe --platforms=macos ."),
 				flutter.New("flutter pub get"),
 				flutter.New("flutter build macos --debug"),
 				flutter.New("cp build/nativelib/retrovibed.dylib build/macos/Build/Products/Debug/retrovibed.app/Contents/MacOS/retrovibed.dylib"),


### PR DESCRIPTION
The App Review device that flagged Guideline 2.1(a) runs iPadOS 26.4 on iPad Air (5th gen). The dev iOS workflow now creates and boots that exact simulator under the name 'Retrovibed Review' so launch-time content fetching can be reproduced locally against the same OS the reviewer hits.

Replace the silently-failing vtool fixup with console.RetagSimulator, which extracts the Go cgo c-archive, byte-patches LC_BUILD_VERSION's platform field from macOS (1) to iOS-simulator (7) on each object, and repacks. vtool can't safely retag Go-produced objects (their Mach-O headers have no pad), but the load command's cmdsize is unchanged so a direct byte substitution is sufficient and avoids the entire vtool saga.

Add the missing 'flutter create --platforms=macos' to the macOS dev script so it can scaffold its platform folder symmetric to the iOS script. Without it, 'flutter build macos' aborts with 'No macOS desktop project configured' after the iOS run has stripped the macos folder.