### PR TITLE
add LSApplicationCategoryType to macOS Info.plist

### DIFF
--- a/console/macos/Runner/Info.plist
+++ b/console/macos/Runner/Info.plist
@@ -30,6 +30,8 @@
 	<string>NSApplication</string>
 	<key>ITSAppUsesNonExemptEncryption</key>
 	<false/>
+	<key>LSApplicationCategoryType</key>
+	<string>public.app-category.entertainment</string>
 	<key>FLTEnableImpeller</key>
 	<true/>
 </dict>


### PR DESCRIPTION
altool --upload-app rejects submissions to App Store Connect that lack LSApplicationCategoryType with "Validation failed (409) The product archive is invalid." The .pkg builds and signs cleanly, but never reaches ASC so no build appears in the App Store Connect Build list.

Category public.app-category.entertainment matches the app's media playback/archival surface area. Swap to a different public.app-category.* UTI if a more specific match is warranted.