### PR TITLE
embed Mac App Store provisioning profile and fail pipeline on altool …

### DIFF
--- a/.eg/release/darwin/main.go
+++ b/.eg/release/darwin/main.go
@@ -37,8 +37,10 @@ func main() {
 		Environ("PUB_CACHE", egenv.CacheDirectory(".eg", "dart"))
 
 	tarballapp := filepath.Join(egtarball.Path(tarballs.Retrovibed(tarinfo())), "retrovibed.app")
+	appstoreapp := egenv.CacheDirectory("retrovibed.appstore.app")
 	dmgpath := egenv.CacheDirectory("retrovibed.darwin.arm64.dmg")
 	pkgpath := egenv.CacheDirectory("retrovibed.darwin.arm64.pkg")
+	entitlements := egenv.WorkingDirectory("console", "macos", "Runner", "Release.entitlements")
 	keychainPath := egenv.WorkspaceDirectory("apple.signing.keychain")
 	flutter := runtime.Directory(egenv.WorkingDirectory("console"))
 	shallows := runtime.Directory(egenv.WorkingDirectory("shallows"))
@@ -87,8 +89,14 @@ func main() {
 				egenv.String("", "APPLE_SIGNING_CER"),
 			),
 			release.KeychainAppendPEM(
+				"installer",
 				egenv.String("", "APPLE_MACOS_INSTALLER_KEY"),
 				egenv.String("", "APPLE_MACOS_INSTALLER_CERT"),
+			),
+			release.KeychainAppendPEM(
+				"appstore",
+				egenv.String("", "APPLE_MACOS_APPSTORE_KEY"),
+				egenv.String("", "APPLE_MACOS_APPSTORE_CERT"),
 			),
 			release.AuthKey(
 				apikey,
@@ -108,9 +116,19 @@ func main() {
 				shell.Newf("xcrun stapler staple %s", dmgpath),
 			),
 			shell.Op(
+				shell.Newf("rm -rf %s && cp -R %s %s", appstoreapp, tarballapp, appstoreapp),
+			),
+			release.EmbedProvisioningProfile(
+				egenv.String("", "APPLE_MACOS_APPSTORE_PROFILE"),
+				filepath.Join(appstoreapp, "Contents", "embedded.provisionprofile"),
+			),
+			shell.Op(
 				shell.Newf("security unlock-keychain -p %s %s", egenv.RunID(), keychainPath),
-				shell.Newf("productbuild --component %s /Applications --sign \"3rd Party Mac Developer Installer\" --keychain %s %s", tarballapp, keychainPath, pkgpath),
-				shell.Newf("xcrun altool --upload-app --type macos -f %s --apiKey ${APPLE_API_KEY} --apiIssuer ${APPLE_ISSUER_ID}", pkgpath).
+				shell.Newf("codesign --deep --force --options runtime --sign \"Apple Distribution\" --keychain %s %s", keychainPath, appstoreapp),
+				shell.Newf("codesign --force --options runtime --sign \"Apple Distribution\" --entitlements %s --keychain %s %s/Contents/Helpers/retrovibed", entitlements, keychainPath, appstoreapp),
+				shell.Newf("codesign --force --options runtime --sign \"Apple Distribution\" --entitlements %s --keychain %s %s", entitlements, keychainPath, appstoreapp),
+				shell.Newf("productbuild --component %s /Applications --sign \"3rd Party Mac Developer Installer\" --keychain %s %s", appstoreapp, keychainPath, pkgpath),
+				shell.Newf("xcrun altool --upload-app --type macos -f %s --apiKey ${APPLE_API_KEY} --apiIssuer ${APPLE_ISSUER_ID} 2>&1 | tee /tmp/altool.log && ! grep -q 'UPLOAD FAILED' /tmp/altool.log", pkgpath).
 					Environ("APPLE_API_KEY", apikey).
 					Environ("APPLE_ISSUER_ID", issuerid),
 			),

--- a/.eg/release/signing.go
+++ b/.eg/release/signing.go
@@ -102,10 +102,11 @@ func KeychainPEM(base64key, base64cert string) eg.OpFn {
 }
 
 // KeychainAppendPEM imports an additional PEM key and DER certificate into the existing signing keychain.
-func KeychainAppendPEM(base64key, base64cert string) eg.OpFn {
+// label distinguishes temp files when multiple certificates are imported.
+func KeychainAppendPEM(label, base64key, base64cert string) eg.OpFn {
 	return func(ctx context.Context, o eg.Op) error {
-		keypath := egenv.WorkspaceDirectory("apple.installer.key.pem")
-		certpath := egenv.WorkspaceDirectory("apple.installer.cert.der")
+		keypath := egenv.WorkspaceDirectory(fmt.Sprintf("apple.%s.key.pem", label))
+		certpath := egenv.WorkspaceDirectory(fmt.Sprintf("apple.%s.cert.der", label))
 		keychainPath := egenv.WorkspaceDirectory("apple.signing.keychain")
 
 		if err := writeBase64File(keypath, base64key, "installer key"); err != nil {
@@ -154,6 +155,13 @@ func AuthKey(keyid, base64authkey string) eg.OpFn {
 				Environ("APPLE_API_KEY_ID", keyid).
 				Environ("APPLE_AUTH_KEY_PATH", filename),
 		)
+	}
+}
+
+// EmbedProvisioningProfile decodes a provisioning profile and writes it to destpath.
+func EmbedProvisioningProfile(base64profile, destpath string) eg.OpFn {
+	return func(ctx context.Context, o eg.Op) error {
+		return writeBase64File(destpath, base64profile, "embedded provisioning profile")
 	}
 }
 

--- a/.github/workflows/release.macosx.yml
+++ b/.github/workflows/release.macosx.yml
@@ -55,4 +55,4 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          eg compute baremetal -e GH_TOKEN --no-podman --secret=gcpsm://${{ secrets.GCP_PROJECT }}/apple-signing-env --secret=gcpsm://${{ secrets.GCP_PROJECT }}/apple-macos-signing-env --secret=gcpsm://${{ secrets.GCP_PROJECT }}/apple-macos-installer-env release/darwin
+          eg compute baremetal -e GH_TOKEN --no-podman --secret=gcpsm://${{ secrets.GCP_PROJECT }}/apple-signing-env --secret=gcpsm://${{ secrets.GCP_PROJECT }}/apple-macos-signing-env --secret=gcpsm://${{ secrets.GCP_PROJECT }}/apple-macos-installer-env --secret=gcpsm://${{ secrets.GCP_PROJECT }}/apple-macos-appstore-env release/darwin


### PR DESCRIPTION
…upload errors

- adds apple-macos-appstore-env secret to the macos build workflow
- embeds Contents/embedded.provisionprofile before codesigning the App Store .app
- treats altool "UPLOAD FAILED" output as a pipeline failure