### PR TITLE
normalize entitlements <true/> tags for AMFI parser

### DIFF
--- a/console/macos/Runner/DebugProfile.entitlements
+++ b/console/macos/Runner/DebugProfile.entitlements
@@ -3,20 +3,20 @@
 <plist version="1.0">
 	<dict>
 		<key>com.apple.security.app-sandbox</key>
-		<true />
+		<true/>
 		<key>com.apple.security.network.client</key>
-		<true />
+		<true/>
 		<key>com.apple.security.network.server</key>
-		<true />
+		<true/>
 
 		<key>com.apple.security.files.user-selected.read-write</key>
-		<true />
+		<true/>
 
 		<key>com.apple.security.files.downloads.read-write</key>
-		<true />
+		<true/>
 
 		<key>com.apple.security.device.camera</key>
-		<true />
+		<true/>
 
 	</dict>
 </plist>

--- a/console/macos/Runner/Release.entitlements
+++ b/console/macos/Runner/Release.entitlements
@@ -3,20 +3,20 @@
 <plist version="1.0">
 	<dict>
 		<key>com.apple.security.app-sandbox</key>
-		<true />
+		<true/>
 		<key>com.apple.security.network.client</key>
-		<true />
+		<true/>
 		<key>com.apple.security.network.server</key>
-		<true />
+		<true/>
 
 		<key>com.apple.security.files.user-selected.read-write</key>
-		<true />
+		<true/>
 
 		<key>com.apple.security.files.downloads.read-write</key>
-		<true />
+		<true/>
 
 		<key>com.apple.security.device.camera</key>
-		<true />
+		<true/>
 
 	</dict>
 </plist>


### PR DESCRIPTION
Xcode 26's AMFI plist parser rejects <true /> (space before /) when codesigning with --entitlements. Switch to canonical <true/> form.