### PR TITLE
chmod a+rX on App Store .app copy before productbuild

### DIFF
--- a/.eg/release/darwin/main.go
+++ b/.eg/release/darwin/main.go
@@ -116,7 +116,7 @@ func main() {
 				shell.Newf("xcrun stapler staple %s", dmgpath),
 			),
 			shell.Op(
-				shell.Newf("rm -rf %s && cp -R %s %s", appstoreapp, tarballapp, appstoreapp),
+				shell.Newf("rm -rf %s && cp -R %s %s && chmod -R a+rX %s", appstoreapp, tarballapp, appstoreapp, appstoreapp),
 			),
 			release.EmbedProvisioningProfile(
 				egenv.String("", "APPLE_MACOS_APPSTORE_PROFILE"),


### PR DESCRIPTION
Apple's pkg validator rejects installers containing files readable only by root. The CI runner's cp -R preserves restrictive modes from build artifacts; chmod -R a+rX makes every file world-readable and keeps directories traversable.