### PR TITLE
add application-identifier to Release.entitlements

### DIFF
--- a/console/macos/Runner/Release.entitlements
+++ b/console/macos/Runner/Release.entitlements
@@ -2,6 +2,10 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 	<dict>
+		<key>com.apple.application-identifier</key>
+		<string>D8T9226P6F.space.retrovibe.retrovibed</string>
+		<key>com.apple.developer.team-identifier</key>
+		<string>D8T9226P6F</string>
 		<key>com.apple.security.app-sandbox</key>
 		<true/>
 		<key>com.apple.security.network.client</key>


### PR DESCRIPTION
Apple rejected the upload with ITMS-90886: the signed bundle entitlements did not include com.apple.application-identifier even though the embedded provisioning profile declared one. Xcode normally merges this from the profile; our eg pipeline passes the entitlements file as-is, so the keys must be present explicitly.