### PR TITLE
include all Go exports in EnforceBinding to defeat dead-stripping

### DIFF
--- a/console/ios/Classes/EnforceBinding.m
+++ b/console/ios/Classes/EnforceBinding.m
@@ -8,6 +8,12 @@ __attribute__((used)) void enforce_binding() {
 	authn_bearer_host("");
 	public_key();
 	username();
+	unseed();
+	seed("");
 	ips();
+	gsetenv("", "");
 	egdaemon("[]");
+	logging();
+	checkpointdb();
+	validatecert("", (unsigned char *)"", 0);
 }


### PR DESCRIPTION
iOS apps statically link the Go bindings, and Xcode's linker strips unreferenced exports. The stub only listed 7 of 13 exports, so any DynamicLibrary.lookup for the missing names (logging, seed, unseed, gsetenv, checkpointdb, validatecert) failed at runtime with a Dart FFI dlsym error and a whitescreen on launch. Reference every export.