### PR TITLE
document EnforceBinding requirement on Go FFI exports

### DIFF
--- a/console/retrovibedbind/main.go
+++ b/console/retrovibedbind/main.go
@@ -1,3 +1,8 @@
+// Every //export directive in this file MUST also be referenced from
+// console/ios/Classes/EnforceBinding.m. iOS links the Go bindings as a
+// static archive and the Apple linker dead-strips any exported symbol
+// the Obj-C/Swift code does not reference, causing Dart FFI dlsym
+// lookups to fail at runtime with a whitescreen on launch.
 package main
 
 import "C"


### PR DESCRIPTION
A missing entry caused a whitescreen on the App Store TestFlight build because the iOS linker stripped the unreferenced 'logging' export. Warn at the top of main.go so future additions don't repeat it.