### PR TITLE
force-load libretrovibed.a from the iOS build env OTHER_LDFLAGS

### DIFF
--- a/.eg/release/ios/main.go
+++ b/.eg/release/ios/main.go
@@ -100,7 +100,7 @@ func iosbuild(ctx context.Context, op eg.Op) error {
 				flutter.New("pod install").Directory(egenv.WorkingDirectory("console", "ios")),
 				// Force Xcode to link the static library and C++ symbols during the final IPA build
 				flutter.New(commit.StringReplace("flutter build ipa --build-name=%git.commit.year%.%git.commit.month%.%git.commit.day% --build-number=%git.commit.unix% --no-codesign --release --build-number=%git.commit.unix%")).
-					Environ("OTHER_LDFLAGS", "-force_load $(PROJECT_DIR)/libduckdb_static.a -lc++").
+					Environ("OTHER_LDFLAGS", "-force_load $(PROJECT_DIR)/libretrovibed.a -force_load $(PROJECT_DIR)/libduckdb_static.a -lc++").
 					Timeout(15*time.Minute),
 			),
 			shell.Op(


### PR DESCRIPTION
The podspec sets OTHER_LDFLAGS via user_target_xcconfig to -force_load every vendored .a, but our flutter build invocation passes OTHER_LDFLAGS as an environment variable which Xcode treats as a wholesale override of the xcconfig value. Only -force_load libduckdb_static.a was reaching the link line; libretrovibed.a was not, so the linker dead-stripped Go FFI exports that EnforceBinding.m references because nothing in the Runner target itself reaches enforce_binding(). Include libretrovibed.a in the env override so the entire Go archive is preserved at link time.