### PR TITLE
export dynamic symbols so Dart FFI dlsym can find Go //export functions

### DIFF
--- a/.eg/release/ios/main.go
+++ b/.eg/release/ios/main.go
@@ -100,7 +100,7 @@ func iosbuild(ctx context.Context, op eg.Op) error {
 				flutter.New("pod install").Directory(egenv.WorkingDirectory("console", "ios")),
 				// Force Xcode to link the static library and C++ symbols during the final IPA build
 				flutter.New(commit.StringReplace("flutter build ipa --build-name=%git.commit.year%.%git.commit.month%.%git.commit.day% --build-number=%git.commit.unix% --no-codesign --release --build-number=%git.commit.unix%")).
-					Environ("OTHER_LDFLAGS", "-force_load $(PROJECT_DIR)/libretrovibed.a -force_load $(PROJECT_DIR)/libduckdb_static.a -lc++").
+					Environ("OTHER_LDFLAGS", "-force_load $(PROJECT_DIR)/libretrovibed.a -force_load $(PROJECT_DIR)/libduckdb_static.a -lc++ -Wl,-export_dynamic").
 					Timeout(15*time.Minute),
 			),
 			shell.Op(


### PR DESCRIPTION
Locally built the Go c-archive for ios_arm64 and confirmed with nm that _logging is present as a global text symbol:

    0000000000000360 T _logging
    0000000000c85e50 T __cgoexp_8260468d91f9_logging

EnforceBinding.m calling logging() made the build link successfully, proving _logging is in the final Runner Mach-O. Yet runtime dlsym( RTLD_DEFAULT, "logging") kept returning not-found. On iOS, ld64 does not put executable globals into the LC_DYLD_INFO exports trie by default the way it does for dylibs; DynamicLibrary.process().lookup searches that trie and comes up empty.

-Wl,-export_dynamic is ld64's flag to include every defined external in the exports trie, making the Go //export symbols discoverable via dlsym from Dart FFI.