### PR TITLE
explicitly list Go FFI exports via -exported_symbols_list

### DIFF
--- a/.eg/release/ios/main.go
+++ b/.eg/release/ios/main.go
@@ -100,7 +100,7 @@ func iosbuild(ctx context.Context, op eg.Op) error {
 				flutter.New("pod install").Directory(egenv.WorkingDirectory("console", "ios")),
 				// Force Xcode to link the static library and C++ symbols during the final IPA build
 				flutter.New(commit.StringReplace("flutter build ipa --build-name=%git.commit.year%.%git.commit.month%.%git.commit.day% --build-number=%git.commit.unix% --no-codesign --release --build-number=%git.commit.unix%")).
-					Environ("OTHER_LDFLAGS", "-force_load $(PROJECT_DIR)/libretrovibed.a -force_load $(PROJECT_DIR)/libduckdb_static.a -lc++ -Wl,-export_dynamic").
+					Environ("OTHER_LDFLAGS", "-force_load $(PROJECT_DIR)/libretrovibed.a -force_load $(PROJECT_DIR)/libduckdb_static.a -lc++ -Wl,-exported_symbols_list,$(PROJECT_DIR)/RetrovivedBind.exports.txt").
 					Timeout(15*time.Minute),
 			),
 			shell.Op(

--- a/console/ios/.gitignore
+++ b/console/ios/.gitignore
@@ -5,6 +5,7 @@
 !.gitignore
 !Podfile
 !RetrovivedBind.podspec
+!RetrovivedBind.exports.txt
 !ExportOptions.plist
 !Classes/
 !Classes/EnforceBinding.m

--- a/console/ios/RetrovivedBind.exports.txt
+++ b/console/ios/RetrovivedBind.exports.txt
@@ -1,0 +1,15 @@
+__GoStringLen
+__GoStringPtr
+_oauth2_bearer
+_authn_bearer
+_authn_bearer_host
+_public_key
+_username
+_unseed
+_seed
+_ips
+_gsetenv
+_egdaemon
+_logging
+_checkpointdb
+_validatecert


### PR DESCRIPTION
Replaces -Wl,-export_dynamic, which only affects LTO (disabled in Flutter release builds) and does not put symbols into the exports trie. For iOS executables, ld64 populates LC_DYLD_INFO_ONLY exports only via -exported_symbol / -exported_symbols_list. dlsym(RTLD_DEFAULT , ...) searches that trie, so without this the Go //export symbols stayed unreachable from Dart FFI despite -force_load having pulled them into the binary's .text.

Keep console/ios/RetrovivedBind.exports.txt under source control so adding a new //export is a two-file change: the Go file plus this list.