### PR TITLE
add nm audit of Runner binary to diagnose Go FFI export presence

### DIFF
--- a/.eg/release/ios/main.go
+++ b/.eg/release/ios/main.go
@@ -102,6 +102,7 @@ func iosbuild(ctx context.Context, op eg.Op) error {
 				flutter.New(commit.StringReplace("flutter build ipa --build-name=%git.commit.year%.%git.commit.month%.%git.commit.day% --build-number=%git.commit.unix% --no-codesign --release --build-number=%git.commit.unix%")).
 					Environ("OTHER_LDFLAGS", "-force_load $(PROJECT_DIR)/libretrovibed.a -force_load $(PROJECT_DIR)/libduckdb_static.a -lc++").
 					Timeout(15*time.Minute),
+				flutter.New("echo '--- Runner binary symbol audit ---' && nm -gU build/ios/archive/Runner.xcarchive/Products/Applications/Runner.app/Runner | grep -E '_(logging|oauth2_bearer|checkpointdb)$$' || echo 'NO GO EXPORTS IN RUNNER BINARY'"),
 			),
 			shell.Op(
 				shell.New("echo flutter failed to build iOS app"),


### PR DESCRIPTION
Prints whether _logging, _oauth2_bearer, and _checkpointdb survive into the Runner executable's global symbol table after link + strip. Output appears in the CI log — no TestFlight install needed to read the result.