### PR TITLE
include Pods xcconfig in Flutter Release/Debug configs

### DIFF
--- a/.eg/release/ios/main.go
+++ b/.eg/release/ios/main.go
@@ -102,7 +102,6 @@ func iosbuild(ctx context.Context, op eg.Op) error {
 				flutter.New(commit.StringReplace("flutter build ipa --build-name=%git.commit.year%.%git.commit.month%.%git.commit.day% --build-number=%git.commit.unix% --no-codesign --release --build-number=%git.commit.unix%")).
 					Environ("OTHER_LDFLAGS", "-force_load $(PROJECT_DIR)/libretrovibed.a -force_load $(PROJECT_DIR)/libduckdb_static.a -lc++").
 					Timeout(15*time.Minute),
-				flutter.New("echo '--- Runner binary symbol audit ---' && nm -gU build/ios/archive/Runner.xcarchive/Products/Applications/Runner.app/Runner | grep -E '_(logging|oauth2_bearer|checkpointdb)$$' || echo 'NO GO EXPORTS IN RUNNER BINARY'"),
 			),
 			shell.Op(
 				shell.New("echo flutter failed to build iOS app"),

--- a/console/ios/.gitignore
+++ b/console/ios/.gitignore
@@ -6,6 +6,9 @@
 !Podfile
 !RetrovivedBind.podspec
 !ExportOptions.plist
+!Flutter/
+!Flutter/Release.xcconfig
+!Flutter/Debug.xcconfig
 !Classes/
 !Classes/EnforceBinding.m
 !Runner/

--- a/console/ios/Flutter/Debug.xcconfig
+++ b/console/ios/Flutter/Debug.xcconfig
@@ -1,0 +1,2 @@
+#include? "Pods/Target Support Files/Pods-Runner/Pods-Runner.debug.xcconfig"
+#include "Generated.xcconfig"

--- a/console/ios/Flutter/Release.xcconfig
+++ b/console/ios/Flutter/Release.xcconfig
@@ -1,0 +1,2 @@
+#include? "Pods/Target Support Files/Pods-Runner/Pods-Runner.release.xcconfig"
+#include "Generated.xcconfig"


### PR DESCRIPTION
The CI log had this CocoaPods warning on every build:

    [!] CocoaPods did not set the base configuration of your project
    because your project already has a custom config set.

Flutter generates Release.xcconfig with only Generated.xcconfig included. The Pods-Runner.release.xcconfig — which carries every -force_load flag from RetrovivedBind.podspec — was never loaded by the Runner target. Result: libretrovibed.a's Go //export symbols were never linked into the Runner binary, and dlsym failed at runtime regardless of any OTHER_LDFLAGS overrides we attempted.

Check in Release.xcconfig and Debug.xcconfig with the standard Pods #include? line so the force_load flags reach ld64. Remove the nm audit diagnostic now that we've identified the issue.