### PR TITLE
exclude libretrovibed.a from vendored_libraries to fix force_load ord…

### DIFF
--- a/console/ios/RetrovivedBind.podspec
+++ b/console/ios/RetrovivedBind.podspec
@@ -9,7 +9,7 @@ Pod::Spec.new do |s|
   s.platform     = :ios, '16.0'
 
   static_libs = Dir[File.join(__dir__, '*.a')].map { |f| File.basename(f) }
-  s.vendored_libraries = static_libs
+  s.vendored_libraries = static_libs.reject { |f| f == 'libretrovibed.a' }
   s.static_framework = true
   s.source_files = 'Classes/**/*.{h,m}'
   s.public_header_files = 'Classes/**/*.h'


### PR DESCRIPTION
…ering

CocoaPods generates -l"retrovibed" from vendored_libraries AND -force_load from user_target_xcconfig. In the final xcconfig, -l appears before -force_load. ld64 processes flags left to right: -l opens the archive and pulls only objects resolving current undefined symbols (none reference _logging). When -force_load is reached later, ld64 considers the archive already consumed and skips it.

Exclude libretrovibed.a from vendored_libraries so -l"retrovibed" is not emitted. The archive is now referenced solely via -force_load which loads every object unconditionally on first encounter.