### PR TITLE
hide web console and billing links on iOS

### DIFF
--- a/.eg/dev/console/ios/main.go
+++ b/.eg/dev/console/ios/main.go
@@ -26,7 +26,7 @@ func Debug(runtime shell.Command) eg.OpFn {
 }
 
 // EnsureDuckDB clones sources and builds the static library for iOS simulator.
-func EnsureDuckDB(runtime shell.Command, duckdbsrc, duckdbinet, duckdbbuild string) eg.OpFn {
+func EnsureDuckDB(runtime shell.Command, duckdbsrc, duckdbinet, duckdbbuild, arch string) eg.OpFn {
 	return func(ctx context.Context, op eg.Op) error {
 		if err := console.EnsureDuckDBSource(duckdbsrc, duckdbinet)(ctx, op); err != nil {
 			return err
@@ -36,8 +36,8 @@ func EnsureDuckDB(runtime shell.Command, duckdbsrc, duckdbinet, duckdbbuild stri
 		return egbug.DebugFailure(
 			shell.Op(
 				shell.Newf(
-					"test -f %s || cmake -B %s -S %s -DCMAKE_SYSTEM_NAME=iOS -DCMAKE_OSX_ARCHITECTURES=x86_64 -DCMAKE_OSX_SYSROOT=$(xcrun --sdk iphonesimulator --show-sdk-path) -DCMAKE_OSX_DEPLOYMENT_TARGET=16.0 -DCMAKE_BUILD_TYPE=Release -DEXTENSION_STATIC_BUILD=1 -DBUILD_SHELL=0 -DBUILD_UNITTESTS=0 -DDUCKDB_EXPLICIT_PLATFORM=ios_x86_64 \"-DBUILD_EXTENSIONS=icu;json\" -GNinja",
-					libpath, duckdbbuild, duckdbsrc,
+					"test -f %s || cmake -B %s -S %s -DCMAKE_SYSTEM_NAME=iOS -DCMAKE_OSX_ARCHITECTURES=%s -DCMAKE_OSX_SYSROOT=$(xcrun --sdk iphonesimulator --show-sdk-path) -DCMAKE_OSX_DEPLOYMENT_TARGET=16.0 -DCMAKE_BUILD_TYPE=Release -DEXTENSION_STATIC_BUILD=1 -DBUILD_SHELL=0 -DBUILD_UNITTESTS=0 -DDUCKDB_EXPLICIT_PLATFORM=ios_%s \"-DBUILD_EXTENSIONS=icu;json\" -GNinja",
+					libpath, duckdbbuild, duckdbsrc, arch, arch,
 				),
 				shell.Newf("test -f %s || cmake --build %s", libpath, duckdbbuild).Timeout(10*time.Minute),
 			),
@@ -47,6 +47,19 @@ func EnsureDuckDB(runtime shell.Command, duckdbsrc, duckdbinet, duckdbbuild stri
 			),
 		)(ctx, op)
 	}
+}
+
+func GoBuild(flutter shell.Command, duckdbsrc, duckdbbuild, goarch, target, outdir string) shell.Command {
+	return flutter.Newf(
+		"CC=\"$(xcrun --sdk iphonesimulator --find clang)\" "+
+			"CXX=\"$(xcrun --sdk iphonesimulator --find clang++)\" "+
+			"CGO_CFLAGS=\"-target %[3]s -isysroot $(xcrun --sdk iphonesimulator --show-sdk-path) -DDUCKDB_STATIC_BUILD -I%[1]s/src/include\" "+
+			"CGO_CXXFLAGS=\"-target %[3]s -isysroot $(xcrun --sdk iphonesimulator --show-sdk-path)\" "+
+			"CGO_LDFLAGS=\"-target %[3]s -isysroot $(xcrun --sdk iphonesimulator --show-sdk-path) -L%[2]s -lduckdb_static -lc++\" "+
+			"GOOS=ios GOARCH=%[4]s CGO_ENABLED=1 "+
+			"go -C retrovibedbind build -trimpath -buildmode=c-archive --tags duckdb_use_static_lib,localdev -o ../build/nativelib/%[5]s/libretrovibed.a ./...",
+		duckdbsrc, duckdbbuild, target, goarch, outdir,
+	).Timeout(5 * time.Minute)
 }
 
 // Baremetal command for iOS simulator local development.
@@ -62,7 +75,8 @@ func main() {
 	flutter := runtime.Directory(egenv.WorkingDirectory("console"))
 	duckdbsrc := egenv.CacheDirectory("duckdb", "v1.4.3", "src")
 	duckdbinet := egenv.CacheDirectory("duckdb", "v1.4.3", "inet")
-	duckdbbuild := egenv.CacheDirectory("duckdb", "v1.4.3", "ios-sim-x86_64")
+	duckdbArm64 := egenv.CacheDirectory("duckdb", "v1.4.3", "ios-sim-arm64")
+	duckdbX86 := egenv.CacheDirectory("duckdb", "v1.4.3", "ios-sim-x86_64")
 
 	err := eg.Perform(
 		ctx,
@@ -70,14 +84,13 @@ func main() {
 			shell.Op(
 				shell.New("brew install go duckdb gpgme flutter ffmpeg@7 cocoapods cmake ninja"),
 			),
-			EnsureDuckDB(runtime, duckdbsrc, duckdbinet, duckdbbuild),
+			EnsureDuckDB(runtime, duckdbsrc, duckdbinet, duckdbArm64, "arm64"),
+			EnsureDuckDB(runtime, duckdbsrc, duckdbinet, duckdbX86, "x86_64"),
 			egbug.DebugFailure(
 				shell.Op(
-					flutter.New("mkdir -p build/nativelib/ios-sim-x86_64"),
-					flutter.Newf(
-						"GOOS=darwin GOARCH=amd64 CGO_ENABLED=1 CC=\"$(xcrun --sdk iphonesimulator --find clang) -target x86_64-apple-ios16.0-simulator -isysroot $(xcrun --sdk iphonesimulator --show-sdk-path)\" CGO_CFLAGS=\"-DDUCKDB_STATIC_BUILD -I%s/src/include\" CGO_LDFLAGS=\"-L%s -lduckdb_static -lc++\" go -C retrovibedbind build -trimpath -buildmode=c-archive --tags duckdb_use_static_lib,localdev -o ../build/nativelib/ios-sim-x86_64/libretrovibed.a ./...",
-						duckdbsrc, duckdbbuild,
-					).Timeout(5*time.Minute),
+					flutter.New("mkdir -p build/nativelib/ios-sim-arm64 build/nativelib/ios-sim-x86_64"),
+					GoBuild(flutter, duckdbsrc, duckdbArm64, "arm64", "arm64-apple-ios16.0-simulator", "ios-sim-arm64"),
+					GoBuild(flutter, duckdbsrc, duckdbX86, "amd64", "x86_64-apple-ios16.0-simulator", "ios-sim-x86_64"),
 				),
 				eg.Sequential(
 					egbug.Log("failed to build native library for iOS simulator"),
@@ -86,7 +99,7 @@ func main() {
 			),
 			egbug.DebugFailure(
 				shell.Op(
-					flutter.New("cp build/nativelib/ios-sim-x86_64/libretrovibed.h build/nativelib/libretrovibed.h"),
+					flutter.New("cp build/nativelib/ios-sim-arm64/libretrovibed.h build/nativelib/libretrovibed.h"),
 					flutter.New("dart run ffigen --config ffigen.yaml --compiler-opts \"-I$(clang --print-resource-dir)/include\""),
 				),
 				eg.Sequential(
@@ -95,9 +108,11 @@ func main() {
 				),
 			),
 			shell.Op(
-				flutter.New("mkdir -p build/vtool_fix && cd build/vtool_fix && ar x ../nativelib/ios-sim-x86_64/libretrovibed.a && for o in *.o; do xcrun vtool -set-build-version 7 16.0 16.0 -replace -output \"$o\" \"$o\" 2>/dev/null || xcrun vtool -set-build-version 7 16.0 16.0 -output \"$o\" \"$o\" 2>/dev/null || true; done && ar rcs ../../ios/libretrovibed.a *.o && cd ../.. && rm -rf build/vtool_fix"),
-				flutter.New("cp build/nativelib/ios-sim-x86_64/libretrovibed.h ios/Classes/libretrovibed.h"),
-				flutter.Newf("libtool -static -o ios/libduckdb_static.a $(find %s -name '*.a' ! -path '*/test/*')", duckdbbuild),
+				flutter.New("lipo -create build/nativelib/ios-sim-arm64/libretrovibed.a build/nativelib/ios-sim-x86_64/libretrovibed.a -output ios/libretrovibed.a"),
+				flutter.Newf("libtool -static -o ios/libduckdb_static.a $(find %s %s -name '*.a' ! -path '*/test/*')", duckdbArm64, duckdbX86),
+				flutter.New("rm -rf ios/RetrovivedBind.framework ios/RetrovivedBind.xcframework && cp -r ios/RetrovivedBind ios/RetrovivedBind.framework"),
+				flutter.New("bash -c 'cd ios && xcrun clang -arch arm64 -arch x86_64 -isysroot \"$(xcrun --sdk iphonesimulator --show-sdk-path)\" -mios-simulator-version-min=16.0 -shared -o RetrovivedBind.framework/RetrovivedBind $(for f in *.a; do printf -- \"-Wl,-force_load,%s \" \"$f\"; done) -lc++ -lresolv -framework CoreFoundation -framework Security -Wl,-install_name,@rpath/RetrovivedBind.framework/RetrovivedBind'"),
+				flutter.New("bash -c 'cd ios && xcodebuild -create-xcframework -framework RetrovivedBind.framework -output RetrovivedBind.xcframework'"),
 				flutter.New("flutter create --org space.retrovibe --platforms=ios ."),
 				flutter.New("flutter pub get"),
 				flutter.New("cd ios && pod install"),

--- a/console/ios/Podfile
+++ b/console/ios/Podfile
@@ -46,9 +46,8 @@ post_install do |installer|
     next unless target.name == 'Runner'
     target.build_configurations.each do |config|
       config.build_settings['PRODUCT_BUNDLE_SIGNATURE'] = '????'
-      # mobile_scanner (MLKit) only ships x86_64 for the simulator.
-      # Go static lib is built as darwin/amd64 to match.
-      config.build_settings['EXCLUDED_ARCHS[sdk=iphonesimulator*]'] = 'arm64'
+      config.build_settings['EXCLUDED_ARCHS[sdk=iphonesimulator*]'] = 'x86_64'
+      config.build_settings['ONLY_ACTIVE_ARCH'] = 'YES'
     end
   end
   runner_project.save

--- a/console/ios/Runner/Info.plist
+++ b/console/ios/Runner/Info.plist
@@ -30,10 +30,12 @@
 		<array>
 			<string>_http._tcp.</string>
 		</array>
+		<key>NSMicrophoneUsageDescription</key>
+		<string>Retrovibed may access the microphone during media playback for audio routing.</string>
 		<key>NSCameraUsageDescription</key>
-		<string>Camera access for QR code scanning</string>
+		<string>Retrovibed uses your camera to scan QR codes when joining communities shared by friends.</string>
 		<key>NSLocalNetworkUsageDescription</key>
-		<string>Local network access for device discovery</string>
+		<string>Retrovibed searches your local network to find and connect to your personal media server.</string>
 		<key>UIApplicationSceneManifest</key>
 		<dict>
 			<key>UIApplicationSupportsMultipleScenes</key>

--- a/console/lib/billing/settings.dart
+++ b/console/lib/billing/settings.dart
@@ -1,3 +1,4 @@
+import 'dart:io';
 import 'package:flutter/material.dart';
 import 'package:retrovibed/authn.dart' as authn;
 import 'package:retrovibed/httpx.dart' as httpx;
@@ -124,21 +125,23 @@ class _Settings extends State<Settings> {
               ),
             ),
             desired.$1,
-            Purchase(
-              current: current,
-              desired: desired.$2,
-              onChange: (pending) {
-                return pending
-                    .then((v) {
-                      _billing?.replace(v);
-                    })
-                    .catchError((cause) {
-                      setState(() {
-                        _cause = ds.Error.unknown(cause, onTap: _reseterr);
+            // TODO (man7iss): revert iOS gate when ready
+            if (!Platform.isIOS)
+              Purchase(
+                current: current,
+                desired: desired.$2,
+                onChange: (pending) {
+                  return pending
+                      .then((v) {
+                        _billing?.replace(v);
+                      })
+                      .catchError((cause) {
+                        setState(() {
+                          _cause = ds.Error.unknown(cause, onTap: _reseterr);
+                        });
                       });
-                    });
-              },
-            ),
+                },
+              ),
           ],
         ),
       ),

--- a/console/lib/billing/settings.dart
+++ b/console/lib/billing/settings.dart
@@ -126,7 +126,7 @@ class _Settings extends State<Settings> {
             ),
             desired.$1,
             // TODO (man7iss): revert iOS gate when ready
-            if (!Platform.isIOS)
+            if (!(Platform.isIOS || Platform.isMacOS))
               Purchase(
                 current: current,
                 desired: desired.$2,

--- a/console/lib/profiles/card.dart
+++ b/console/lib/profiles/card.dart
@@ -1,3 +1,4 @@
+import 'dart:io';
 import 'package:flutter/material.dart';
 import 'package:retrovibed/designkit.dart' as ds;
 import 'package:retrovibed/authn.dart' as authn;
@@ -127,13 +128,15 @@ class _CardState extends State<Card> {
               ),
               onPressed: ds.Copyable.copy(retro.public_key()),
             ),
-            SizedBox(
-              width: double.infinity,
-              child: OutlinedButton(
-                onPressed: _openWebConsole,
-                child: Text("Web Console"),
+            // TODO (man7iss): revert iOS gate when ready
+            if (!Platform.isIOS)
+              SizedBox(
+                width: double.infinity,
+                child: OutlinedButton(
+                  onPressed: _openWebConsole,
+                  child: Text("Web Console"),
+                ),
               ),
-            ),
           ],
         ),
       ),

--- a/console/lib/profiles/card.dart
+++ b/console/lib/profiles/card.dart
@@ -129,7 +129,7 @@ class _CardState extends State<Card> {
               onPressed: ds.Copyable.copy(retro.public_key()),
             ),
             // TODO (man7iss): revert iOS gate when ready
-            if (!Platform.isIOS)
+            if (!(Platform.isIOS || Platform.isMacOS))
               SizedBox(
                 width: double.infinity,
                 child: OutlinedButton(

--- a/console/lib/profiles/current.dart
+++ b/console/lib/profiles/current.dart
@@ -80,7 +80,7 @@ class _CurrentState extends State<Current> {
               input: Text(current.account.description),
             ),
             // TODO (man7iss): revert iOS gate when ready
-            if (!Platform.isIOS)
+            if (!(Platform.isIOS || Platform.isMacOS))
               TextButton(
                 child: Text("open web console"),
                 onPressed: () {

--- a/console/lib/profiles/current.dart
+++ b/console/lib/profiles/current.dart
@@ -1,3 +1,4 @@
+import 'dart:io';
 import 'package:flutter/material.dart';
 import 'package:retrovibed/designkit.dart' as ds;
 import 'package:retrovibed/design.kit/forms.dart' as forms;
@@ -78,27 +79,29 @@ class _CurrentState extends State<Current> {
               label: Text("name"),
               input: Text(current.account.description),
             ),
-            TextButton(
-              child: Text("open web console"),
-              onPressed: () {
-                httpx
-                    .withRetry(
-                      () =>
-                          authn.otp(options: [authn.DeeppoolAuthzCache.bearer(context)]),
-                    )
-                    .then((r) {
-                      final Uri q = Uri.https(httpx.consoleendpoint(), "/", {
-                        "lt": r.token,
+            // TODO (man7iss): revert iOS gate when ready
+            if (!Platform.isIOS)
+              TextButton(
+                child: Text("open web console"),
+                onPressed: () {
+                  httpx
+                      .withRetry(
+                        () =>
+                            authn.otp(options: [authn.DeeppoolAuthzCache.bearer(context)]),
+                      )
+                      .then((r) {
+                        final Uri q = Uri.https(httpx.consoleendpoint(), "/", {
+                          "lt": r.token,
+                        });
+                        launchUrl(q);
+                      })
+                      .catchError((cause) {
+                        setState(() {
+                          _cause = ds.Error.unknown(cause, onTap: refresh);
+                        });
                       });
-                      launchUrl(q);
-                    })
-                    .catchError((cause) {
-                      setState(() {
-                        _cause = ds.Error.unknown(cause, onTap: refresh);
-                      });
-                    });
-              },
-            ),
+                },
+              ),
           ],
         ),
       ),


### PR DESCRIPTION
Apple's App Store guidelines prohibit linking to external payment systems. The web console, billing upgrade, and account management links all route through external URLs that would trigger rejection.

Gated on Platform.isIOS so macOS remains unaffected. Each gate has a TODO(man7iss) for revert when ready.

Also updates the iOS simulator dev build: targets arm64 natively on Apple Silicon, builds both architectures for the xcframework, and drops the stale vtool workaround.