### PR TITLE
show recommendations and new releases with zero-state messaging

### DIFF
--- a/console/lib/design.kit/carousel.dart
+++ b/console/lib/design.kit/carousel.dart
@@ -97,7 +97,7 @@ class _CarouselRowState extends State<CarouselRow> {
                     Stack(
                       children: [
                         if (widget.items.isEmpty) widget.background,
-                        if (widget.items.isEmpty) Center(child: widget.empty),
+                        if (widget.items.isEmpty && !widget.loading) Center(child: widget.empty),
                         Listener(
                           onPointerSignal: (event) {
                             if (event is PointerScrollEvent) {

--- a/console/lib/design.kit/carousel.dart
+++ b/console/lib/design.kit/carousel.dart
@@ -13,6 +13,7 @@ class CarouselRow extends StatefulWidget {
   final bool loading;
   final Widget cause;
   final Widget background;
+  final Widget empty;
 
   const CarouselRow({
     super.key,
@@ -21,6 +22,7 @@ class CarouselRow extends StatefulWidget {
     this.loading = false,
     this.cause = Error.zero,
     this.background = const SizedBox(),
+    this.empty = const SizedBox(),
     this.constraints,
   });
 
@@ -95,6 +97,7 @@ class _CarouselRowState extends State<CarouselRow> {
                     Stack(
                       children: [
                         if (widget.items.isEmpty) widget.background,
+                        if (widget.items.isEmpty) Center(child: widget.empty),
                         Listener(
                           onPointerSignal: (event) {
                             if (event is PointerScrollEvent) {

--- a/console/lib/discovery/home.dart
+++ b/console/lib/discovery/home.dart
@@ -47,8 +47,8 @@ class _HomeState extends State<Home> {
           verticalDirection: compact ? VerticalDirection.up : VerticalDirection.down,
           children: [
             Recent(),
-            if (defaults.debug) Recommendations(),
-            if (defaults.debug) NewReleases(),
+            Recommendations(),
+            NewReleases(),
           ],
         ),
       );

--- a/console/lib/discovery/recent.dart
+++ b/console/lib/discovery/recent.dart
@@ -78,16 +78,10 @@ class _RecentState extends State<Recent> {
     return ds.CarouselRow(
       title: const Text('Continue Watching'),
       constraints: BoxConstraints.tightForFinite(height: 256),
-      background: Stack(
-          children: [
-            ds.Repeat(() => lib.KnownMediaCard(lib.Known(), icon: null)),
-            Center(
-              child: Text(
-                'Media you watch will appear here',
-                style: TextStyle(color: Colors.grey),
-              ),
-            ),
-          ],
+      background: ds.Repeat(() => lib.KnownMediaCard(lib.Known(), icon: null)),
+        empty: Text(
+          'Media you watch will appear here',
+          style: TextStyle(color: Colors.grey),
         ),
       items:
           _result.items.map((item) {

--- a/console/lib/discovery/recent.dart
+++ b/console/lib/discovery/recent.dart
@@ -78,7 +78,17 @@ class _RecentState extends State<Recent> {
     return ds.CarouselRow(
       title: const Text('Continue Watching'),
       constraints: BoxConstraints.tightForFinite(height: 256),
-      background: ds.Repeat(() => lib.KnownMediaCard(lib.Known(), icon: null)),
+      background: Stack(
+          children: [
+            ds.Repeat(() => lib.KnownMediaCard(lib.Known(), icon: null)),
+            Center(
+              child: Text(
+                'Media you watch will appear here',
+                style: TextStyle(color: Colors.grey),
+              ),
+            ),
+          ],
+        ),
       items:
           _result.items.map((item) {
             final deletion = () {

--- a/console/lib/discovery/recommendations.dart
+++ b/console/lib/discovery/recommendations.dart
@@ -86,16 +86,10 @@ class _RecommendationsState extends State<Recommendations> {
           ],
         ),
         constraints: BoxConstraints.tightForFinite(height: 256),
-        background: Stack(
-          children: [
-            ds.Repeat(() => lib.KnownMediaCard(lib.Known(), icon: null)),
-            Center(
-              child: Text(
-                'Content partnerships in progress',
-                style: TextStyle(color: Colors.grey),
-              ),
-            ),
-          ],
+        background: ds.Repeat(() => lib.KnownMediaCard(lib.Known(), icon: null)),
+        empty: Text(
+          'Content partnerships in progress',
+          style: TextStyle(color: Colors.grey),
         ),
         items:
             _items

--- a/console/lib/discovery/recommendations.dart
+++ b/console/lib/discovery/recommendations.dart
@@ -86,8 +86,16 @@ class _RecommendationsState extends State<Recommendations> {
           ],
         ),
         constraints: BoxConstraints.tightForFinite(height: 256),
-        background: ds.Repeat(
-          () => lib.KnownMediaCard(lib.Known(), icon: null),
+        background: Stack(
+          children: [
+            ds.Repeat(() => lib.KnownMediaCard(lib.Known(), icon: null)),
+            Center(
+              child: Text(
+                'Content partnerships in progress',
+                style: TextStyle(color: Colors.grey),
+              ),
+            ),
+          ],
         ),
         items:
             _items

--- a/console/lib/discovery/releases.dart
+++ b/console/lib/discovery/releases.dart
@@ -72,16 +72,10 @@ class _NewReleasesState extends State<NewReleases> {
     return ds.CarouselRow(
       title: const Text('New Releases'),
       constraints: BoxConstraints.tightForFinite(height: 256),
-      background: Stack(
-          children: [
-            ds.Repeat(() => lib.KnownMediaCard(lib.Known(), icon: null)),
-            Center(
-              child: Text(
-                'Content partnerships in progress',
-                style: TextStyle(color: Colors.grey),
-              ),
-            ),
-          ],
+      background: ds.Repeat(() => lib.KnownMediaCard(lib.Known(), icon: null)),
+        empty: Text(
+          'Content partnerships in progress',
+          style: TextStyle(color: Colors.grey),
         ),
       items:
           _result.items

--- a/console/lib/discovery/releases.dart
+++ b/console/lib/discovery/releases.dart
@@ -72,7 +72,17 @@ class _NewReleasesState extends State<NewReleases> {
     return ds.CarouselRow(
       title: const Text('New Releases'),
       constraints: BoxConstraints.tightForFinite(height: 256),
-      background: ds.Repeat(() => lib.KnownMediaCard(lib.Known(), icon: null)),
+      background: Stack(
+          children: [
+            ds.Repeat(() => lib.KnownMediaCard(lib.Known(), icon: null)),
+            Center(
+              child: Text(
+                'Content partnerships in progress',
+                style: TextStyle(color: Colors.grey),
+              ),
+            ),
+          ],
+        ),
       items:
           _result.items
               .map(

--- a/console/test/design.kit/carousel_test.dart
+++ b/console/test/design.kit/carousel_test.dart
@@ -231,6 +231,20 @@ void main() {
       expect(find.text('bg'), findsWidgets);
     });
 
+    testWidgets('empty widget is hidden while loading', (tester) async {
+      await tester.pumpApp(
+        CarouselRow(
+          constraints: const BoxConstraints.tightFor(height: 256),
+          title: const Text('Recommendations'),
+          empty: const Text('Content partnerships in progress'),
+          items: const [],
+          loading: true,
+        ),
+      );
+      await tester.pump();
+      expect(find.text('Content partnerships in progress'), findsNothing);
+    });
+
     testWidgets('empty widget is hidden when items are present', (tester) async {
       await tester.pumpApp(
         CarouselRow(

--- a/console/test/design.kit/carousel_test.dart
+++ b/console/test/design.kit/carousel_test.dart
@@ -214,6 +214,39 @@ void main() {
       expect(find.text('card'), findsExactly(5));
     });
 
+    testWidgets('empty widget is shown when items list is empty', (tester) async {
+      await tester.pumpApp(
+        CarouselRow(
+          constraints: const BoxConstraints.tightFor(height: 256),
+          title: const Text('Recommendations'),
+          background: Repeat(
+            () => const SizedBox(width: 100, height: 100, child: Text('bg')),
+          ),
+          empty: const Text('Content partnerships in progress'),
+          items: const [],
+        ),
+      );
+      await tester.pumpAndSettle();
+      expect(find.text('Content partnerships in progress'), findsOneWidget);
+      expect(find.text('bg'), findsWidgets);
+    });
+
+    testWidgets('empty widget is hidden when items are present', (tester) async {
+      await tester.pumpApp(
+        CarouselRow(
+          constraints: const BoxConstraints.tightFor(height: 256),
+          title: const Text('Recommendations'),
+          empty: const Text('Content partnerships in progress'),
+          items: [
+            SizedBox(width: 100, height: 150, child: Text('item')),
+          ],
+        ),
+      );
+      await tester.pumpAndSettle();
+      expect(find.text('Content partnerships in progress'), findsNothing);
+      expect(find.text('item'), findsOneWidget);
+    });
+
     testWidgets('buttons inside items are tappable', (tester) async {
       bool tapped = false;
       await tester.pumpApp(


### PR DESCRIPTION
Users reported a blank screen because both sections were gated behind debug mode. Now they always render, with placeholder text explaining content partnerships are in progress.