### PR TITLE
add privacy purpose strings for Downloads and Camera

### DIFF
--- a/console/macos/Runner/Info.plist
+++ b/console/macos/Runner/Info.plist
@@ -34,5 +34,9 @@
 	<string>public.app-category.entertainment</string>
 	<key>FLTEnableImpeller</key>
 	<true/>
+	<key>NSDownloadsFolderUsageDescription</key>
+	<string>Retrovibe monitors your Downloads folder to auto-detect torrents and uses it as the export destination for media downloaded from the app. For example, when you download a movie, it will be saved to your Downloads folder.</string>
+	<key>NSCameraUsageDescription</key>
+	<string>Retrovibe uses the camera to scan QR codes for joining communities. For example, scanning a printed community invite card.</string>
 </dict>
 </plist>


### PR DESCRIPTION
5.1.1(ii): App Store review requires concrete usage examples in purpose strings for protected resources.