### PR TITLE
redirect go log output to os_log on iOS

### DIFF
--- a/console/retrovibedbind/logging_default.go
+++ b/console/retrovibedbind/logging_default.go
@@ -1,4 +1,4 @@
-//go:build !android
+//go:build !android && !ios
 
 package main
 

--- a/console/retrovibedbind/logging_ios.go
+++ b/console/retrovibedbind/logging_ios.go
@@ -1,0 +1,34 @@
+//go:build ios
+
+package main
+
+/*
+#include <os/log.h>
+#include <stdlib.h>
+
+static void oslog_write(const char *msg) {
+	os_log_with_type(OS_LOG_DEFAULT, OS_LOG_TYPE_DEFAULT, "%{public}s", msg);
+}
+*/
+import "C"
+import (
+	"fmt"
+	"log"
+	"os"
+	"unsafe"
+)
+
+type OSLogWriter struct{}
+
+func (w *OSLogWriter) Write(p []byte) (n int, err error) {
+	msg := C.CString(string(p))
+	defer C.free(unsafe.Pointer(msg))
+	C.oslog_write(msg)
+	return len(p), nil
+}
+
+func redirectlogs() {
+	log.SetFlags(log.Lshortfile | log.LUTC | log.Ltime)
+	log.SetPrefix(fmt.Sprintf("%d ", os.Getpid()))
+	log.SetOutput(&OSLogWriter{})
+}


### PR DESCRIPTION
Go's log package writes to stderr, which Console.app does not surface for embedded frameworks. This makes it impossible to diagnose FFI failures (e.g. BearerForHost errors) on iOS devices.

Adds an os_log writer for the ios build tag, matching the existing logcat writer pattern on Android.