### PR TITLE
force_load libduckdb_static.a to resolve circular symbol reference

### DIFF
--- a/.eg/release/darwin/main.go
+++ b/.eg/release/darwin/main.go
@@ -49,7 +49,8 @@ func main() {
 	duckdblibs := egenv.CacheDirectory("duckdb", ".darwin-arm64")
 
 	duckdbldflags := "-L" + duckdblibs + " " +
-		"-lduckdb_static " +
+		"-Wl,-force_load," + duckdblibs + "/libduckdb_static.a " +
+		"-lduckdb_generated_extension_loader " +
 		"-lautocomplete_extension -lcore_functions_extension -licu_extension -ljson_extension -lparquet_extension " +
 		"-linet_extension -lfts_extension " +
 		"-ltpcds_extension -ltpch_extension " +

--- a/.eg/release/ios/main.go
+++ b/.eg/release/ios/main.go
@@ -36,7 +36,6 @@ func main() {
 		ctx,
 		eg.Sequential(
 			duckdb.MaybeBuild(".eg.cache/duckdb/.arm64/libduckdb_static.a", duckdb.CompileIOS("ios_arm64", "arm64"), duckdb.CloneIOS),
-			// Copy all static libs to the ios folder so Xcode/Pods can find them directly
 			shell.Op(shell.Newf("cp .eg.cache/duckdb/.arm64/*.a console/ios/")),
 			console.GenerateFlutter,
 			egbug.DebugFailure(
@@ -96,7 +95,7 @@ func iosbuild(ctx context.Context, op eg.Op) error {
 		egbug.DebugFailure(
 			shell.Op(
 				flutter.New("rm -rf ios/RetrovivedBind.framework ios/RetrovivedBind.xcframework && cp -r ios/RetrovivedBind ios/RetrovivedBind.framework"),
-				flutter.New("bash -c 'cd ios && xcrun clang -target arm64-apple-ios16.0 -isysroot \"$(xcrun --sdk iphoneos --show-sdk-path)\" -shared -o RetrovivedBind.framework/RetrovivedBind $(for f in *.a; do printf -- \"-Wl,-force_load,%s \" \"$f\"; done) -lc++ -lresolv -framework CoreFoundation -framework Security -Wl,-install_name,@rpath/RetrovivedBind.framework/RetrovivedBind'"),
+				flutter.New("bash -c 'cd ios && xcrun clang -target arm64-apple-ios16.0 -isysroot \"$(xcrun --sdk iphoneos --show-sdk-path)\" -shared -o RetrovivedBind.framework/RetrovivedBind -Wl,-force_load,libretrovibed.a -Wl,-force_load,libduckdb_static.a -Wl,-force_load,libduckdb_generated_extension_loader.a $(for f in lib*_extension.a; do printf -- \"-Wl,-force_load,%s \" \"$f\"; done) -lc++ -lresolv -framework CoreFoundation -framework Security -Wl,-install_name,@rpath/RetrovivedBind.framework/RetrovivedBind'"),
 				flutter.New("bash -c 'cd ios && xcodebuild -create-xcframework -framework RetrovivedBind.framework -output RetrovivedBind.xcframework'"),
 				flutter.New("flutter pub get"),
 				flutter.New("pod install").Directory(egenv.WorkingDirectory("console", "ios")),


### PR DESCRIPTION
DuckDB 1.5.2's libduckdb_static.a has an internal circular dependency: database.cpp references LoadAllExtensions which is defined in extension_helper.cpp within the same archive. The darwin linker processes archives in one pass and misses the back-reference.

macOS: replace -lduckdb_static with -Wl,-force_load on the full archive path so the linker ingests all objects unconditionally.

iOS: copy only libduckdb_static.a (extensions are already compiled into it via EXTENSION_STATIC_BUILD=1). The existing force_load glob then loads libretrovibed.a and libduckdb_static.a without duplicates.