### PR TITLE
cleanup linux builds in preparation for appimage.

### DIFF
--- a/.dist/linux/usr/share/applications/retrovibed.desktop
+++ b/.dist/linux/usr/share/applications/retrovibed.desktop
@@ -1,7 +1,7 @@
 [Desktop Entry]
 Name=Retrovibe Console
 Comment=A versatile application for data archival and media playback.
-Exec=/app/bin/console
+Exec=/usr/lib/retrovibed/console
 Icon=space.retrovibe.Console
 Type=Application
 Categories=Utility;Archiving;AudioVideo;Player;
@@ -9,3 +9,7 @@ Terminal=false
 StartupNotify=true
 StartupWMClass=space.retrovibe.Console
 Keywords=retro;console;emulator;game;archive;data;media;player;video;audio;
+X-AppImage-Version=${VERSION}
+X-AppImage-Name=retrovibed
+X-AppImage-Arch=${ARCH}
+X-AppImage-UpdateInformation=gh-releases-zsync|retrovibed|retrovibed|latest|retrovibed-*-${ARCH}.AppImage.zsync

--- a/.eg/console/console.go
+++ b/.eg/console/console.go
@@ -143,7 +143,7 @@ func GenerateProtocol(ctx context.Context, _ eg.Op) error {
 
 func Install(b *tarballs.Build) eg.OpFn {
 	runtime := shell.Runtime()
-	dstdir := egtarball.Path(tarballs.Retrovibed(b))
+	dstdir := filepath.Join(egtarball.Path(tarballs.Retrovibed(b)), "usr", "lib", "retrovibed")
 	builddir := egenv.WorkingDirectory("console", "build")
 	linuxdir := filepath.Join(builddir, "linux")
 	bundledir := filepath.Join(linuxdir, egfs.FindFirst(os.DirFS(linuxdir), "bundle"))
@@ -151,11 +151,9 @@ func Install(b *tarballs.Build) eg.OpFn {
 	return eg.Sequential(
 		CompileBinding(b),
 		shell.Op(
-			runtime.Newf("echo mkdir -p %s", dstdir),
 			runtime.Newf("mkdir -p %s", dstdir),
 			runtime.Newf("ls -lha  %s/retrovibed", bundledir).Lenient(true),
 			runtime.Newf("mv %s/retrovibed %s/console", bundledir, bundledir),
-			runtime.Newf("echo cp -R %s/* %s", bundledir, dstdir),
 			runtime.Newf("cp -R %s/* %s", bundledir, dstdir),
 			runtime.Newf("cp -R %s/* %s/lib", libdir, dstdir),
 			// runtime.Newf("tree %s", dstdir),

--- a/.eg/console/console.linux.go
+++ b/.eg/console/console.linux.go
@@ -65,7 +65,6 @@ func flatpak(final egflatpak.Module) *egflatpak.Builder {
 		egflatpak.Option().SDK("org.gnome.Sdk", "50").Runtime("org.gnome.Platform", "50").
 			Modules(
 				flatpakmods.Libduckdb(),
-				// flatpakmods.Libduckdbsrc(),
 				flatpakmods.Libass(),
 				flatpakmods.Libbs2b(),
 				flatpakmods.Libplacebo(),
@@ -131,13 +130,14 @@ func FlatpakManifest(b *tarballs.Build) eg.OpFn {
 
 func moduleTarball(url, sha256d string) egflatpak.Module {
 	return egflatpak.NewModule("retrovibed", "simple", egflatpak.ModuleOptions().Commands(
-		"mv usr/share/applications/retrovibed.desktop /app/share/applications/space.retrovibe.Console.desktop",
+		"sed 's|Exec=/usr/lib/retrovibed/console|Exec=/app/bin/console|' usr/share/applications/retrovibed.desktop > /app/share/applications/space.retrovibe.Console.desktop",
 		"mv usr/share/icons/hicolor/scalable/apps/retrovibed.svg /app/share/icons/hicolor/scalable/apps/space.retrovibe.Console.svg",
 		"mv usr/share/metainfo/space.retrovibe.Console.metainfo.xml /app/share/metainfo/space.retrovibe.Console.metainfo.xml",
 		"mv usr/share/licenses/space.retrovibe.Console /app/share/licenses/space.retrovibe.Console",
+		"mv usr/lib/retrovibed/lib /app/lib",
+		"mv usr/lib/retrovibed/* /app/bin",
 		"rm -rf usr",
 		"rm -rf etc",
-		"cp -r . /app/bin",
-		"mv /app/bin/lib/libretrovibed.so /app/lib",
+		"tree -L 2 /",
 	).Sources(egflatpak.SourceTarball(url, sha256d))...)
 }

--- a/.eg/release/linux/main.go
+++ b/.eg/release/linux/main.go
@@ -76,6 +76,15 @@ func build() eg.OpFn {
 			shallows.Install(b),
 			shell.Op(
 				shell.Newf("cp --verbose -R .dist/linux/* %s", egtarball.Path(archive)),
+				shell.Newf(
+					"cat .dist/linux/usr/share/applications/retrovibed.desktop | envsubst > %s/usr/share/applications/retrovibed.desktop",
+					egtarball.Path(archive),
+				).
+					Environ("VERSION", eggit.EnvCommit().StringReplace("%git.commit.year%.%git.commit.month%.%git.commit.day%")).
+					Environ("ARCH", b.Arch),
+				shell.Newf(
+					"cat usr/share/applications/retrovibed.desktop",
+				).Directory(egtarball.Path(archive)),
 			),
 			flathub.Metainfo(b),
 		),

--- a/.eg/shallows/shallows.go
+++ b/.eg/shallows/shallows.go
@@ -3,6 +3,7 @@ package shallows
 import (
 	"context"
 	"eg/compute/tarballs"
+	"path/filepath"
 	"strings"
 	"time"
 
@@ -74,7 +75,7 @@ func GenerateProtocol(ctx context.Context, op eg.Op) error {
 }
 
 func Install(b *tarballs.Build) eg.OpFn {
-	dstdir := egtarball.Path(tarballs.Retrovibed(b))
+	dstdir := filepath.Join(egtarball.Path(tarballs.Retrovibed(b)), "usr", "lib", "retrovibed")
 	gruntime := shellruntime()
 
 	return shell.Op(


### PR DESCRIPTION
appimage is a far simpler and more robust deployment option than flatpak.
- no unncessary review/nonsense opinions from third party requirements to publish.
- easily distributed via github releases.
- has a gui installation frontent.
- has auto update builtin.
- has sandboxing.

basically it does everything flatpak does but simpler and without the gatekeeping nonsense.