### PR TITLE
drop camera entitlement from macOS

### DIFF
--- a/console/macos/Runner/DebugProfile.entitlements
+++ b/console/macos/Runner/DebugProfile.entitlements
@@ -15,8 +15,5 @@
 		<key>com.apple.security.files.downloads.read-write</key>
 		<true/>
 
-		<key>com.apple.security.device.camera</key>
-		<true/>
-
 	</dict>
 </plist>

--- a/console/macos/Runner/Release.entitlements
+++ b/console/macos/Runner/Release.entitlements
@@ -19,8 +19,5 @@
 		<key>com.apple.security.files.downloads.read-write</key>
 		<true/>
 
-		<key>com.apple.security.device.camera</key>
-		<true/>
-
 	</dict>
 </plist>


### PR DESCRIPTION
QR code scanning is iOS-only; macOS has no use for the camera.