### PR TITLE
warn instead of fatal when download folder is inaccessible

### DIFF
--- a/shallows/cmd/retrovibed/daemons/cmd.daemon.downloads_test.go
+++ b/shallows/cmd/retrovibed/daemons/cmd.daemon.downloads_test.go
@@ -1,0 +1,25 @@
+package daemons
+
+import (
+	"context"
+	"crypto/tls"
+	"testing"
+
+	"github.com/retrovibed/retrovibed/shallows/downloads"
+	"github.com/retrovibed/retrovibed/shallows/internal/sqltestx"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDownloadWatcher(t *testing.T) {
+	t.Run("inaccessible directory does not fatal", func(t *testing.T) {
+		db := sqltestx.Metadatabase(t)
+		ctx, cancel := context.WithCancel(t.Context())
+		defer cancel()
+
+		dwatcher, err := downloads.NewDirectoryWatcher(ctx, &tls.Config{}, db)
+		require.NoError(t, err)
+
+		err = dwatcher.Add("/nonexistent/path/that/does/not/exist")
+		require.Error(t, err, "Add should return an error for inaccessible directories")
+	})
+}

--- a/shallows/cmd/retrovibed/daemons/cmd.daemon.go
+++ b/shallows/cmd/retrovibed/daemons/cmd.daemon.go
@@ -44,6 +44,7 @@ import (
 	"github.com/james-lawrence/torrent/storage"
 
 	"github.com/gorilla/mux"
+	"github.com/logrusorgru/aurora"
 )
 
 func DefaultDialer(wgnet *netstack.Net, cache dnscache.Resolver) netx.Dialer {
@@ -235,7 +236,8 @@ func (t Command) Run(gctx *cmdopts.Global, sshid *cmdopts.SSHID, tlscfg *cmdopts
 
 		for _, dir := range t.TorrentFolderWatch {
 			if err = dwatcher.Add(dir); err != nil {
-				return errorsx.Wrapf(err, "unable to watch directory: %s", dir)
+				log.Println(aurora.Yellow("WARNING"), errorsx.Wrapf(err, "unable to watch directory: %s", dir))
+				continue
 			}
 		}
 	} else {


### PR DESCRIPTION
When the user denies the Downloads folder permission dialog on macOS, dwatcher.Add returns an error that propagated to FatalIfErrorf, calling os.Exit and crashing the app via the Go exit / Flutter run loop race.