### PR TITLE
hide archive controls for free plan users

### DIFF
--- a/console/lib/library/known.media.display.dart
+++ b/console/lib/library/known.media.display.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:retrovibed/designkit.dart' as ds;
+import 'package:retrovibed/authn.dart' as authn;
 import 'package:retrovibed/library/known.media.card.dart';
 import 'package:retrovibed/media/media.pb.dart';
 import 'package:retrovibed/media.dart' as _media;
@@ -191,7 +192,10 @@ class _KnownMediaDisplayState extends State<KnownMediaDisplay> {
             children: [
               if (constraints.maxWidth >= 260) ds.Rating(rating: current.rating),
               Expanded(child: KnownMediaSource(current)),
-              uuidx.pattern(widget.media.archiveId, archivable, archiving, purge),
+              Visibility(
+                visible: (authn.AuthzCache.of(context)?.meta.current.metadata.archiveUpload.toInt() ?? 0) > 0,
+                child: uuidx.pattern(widget.media.archiveId, archivable, archiving, purge),
+              ),
               ds.LoadingIconButton(
                 tooltip: "download this file to your downloads folder",
                 onPressed: _media.DownloadAction(context, widget.media),

--- a/console/lib/library/metadata.edit.dart
+++ b/console/lib/library/metadata.edit.dart
@@ -1,9 +1,9 @@
 import 'package:flutter/material.dart';
 import 'package:retrovibed/designkit.dart' as ds;
+import 'package:retrovibed/authn.dart' as authn;
 import 'package:retrovibed/design.kit/forms.dart' as forms;
 import 'package:retrovibed/media.dart' as media;
 import 'package:retrovibed/uuidx.dart' as uuidx;
-import 'package:retrovibed/authn.dart' as authn;
 import './metadata.typography.dart' as typography;
 import './metadata.icons.dart' as icons;
 
@@ -113,9 +113,12 @@ class MediaEdit extends StatelessWidget {
             label: Text("sharing"),
             input: typography.sharing(current.torrentId),
           ),
-          forms.Field(
-            label: Text("archived"),
-            input: archive(context, current.archiveId),
+          Visibility(
+            visible: (authn.AuthzCache.of(context)?.meta.current.metadata.archiveUpload.toInt() ?? 0) > 0,
+            child: forms.Field(
+              label: Text("archived"),
+              input: archive(context, current.archiveId),
+            ),
           ),
         ],
       ),


### PR DESCRIPTION
The archive button (upload to cloud) and the archived field in metadata edit are subscription features. Hiding them for free plan users removes the only visible reference to paid functionality in the standalone app experience.