### PR TITLE
prepare console workload for the eg macvm runner

### DIFF
--- a/.eg/console/console.go
+++ b/.eg/console/console.go
@@ -162,17 +162,24 @@ func Install(b *tarballs.Build) eg.OpFn {
 }
 
 func RunDev(cmd string) eg.OpFn {
+	return RunDevAt(cmd, "localhost")
+}
+
+// RunDevAt is RunDev with the meta/console host overridable so workloads
+// running in an isolated network namespace (Tart guest, remote VM) can point
+// the daemon at a different host. host is embedded into the launch command's
+// env prefix, so callers may pass either a literal hostname/IP or a bash
+// command substitution (e.g. "$(route get default | awk '/gateway:/{print $2}')")
+// to resolve the address at runtime inside the guest.
+func RunDevAt(cmd, host string) eg.OpFn {
 	return func(ctx context.Context, _ eg.Op) error {
 		runtime := flutterRuntimev2(shell.Runtime()).
-			// Environ("RETROVIBED_TORRENT_DEBUG", "true").
-			Environ("RETROVIBED_METADATA_AUTODOWNLOAD", "false").
-			// Environ("RETROVIBED_META_ENDPOINT", "api.retrovibe.space").
-			// Environ("RETROVIBED_CONSOLE_ENDPOINT", "console.retrovibe.space")
-			Environ("RETROVIBED_META_ENDPOINT", "localhost:8081").
-			Environ("RETROVIBED_CONSOLE_ENDPOINT", "localhost:8080")
+			Environ("RETROVIBED_METADATA_AUTODOWNLOAD", "false")
+		prefixed := "RETROVIBED_META_ENDPOINT=" + host + ":8081 " +
+			"RETROVIBED_CONSOLE_ENDPOINT=" + host + ":8080 " + cmd
 		return shell.Run(
 			ctx,
-			runtime.New(cmd).Timeout(egenv.TTL()),
+			runtime.New(prefixed).Timeout(egenv.TTL()),
 		)
 	}
 }

--- a/.eg/dev/console/macos/main.go
+++ b/.eg/dev/console/macos/main.go
@@ -11,7 +11,90 @@ import (
 	"github.com/egdaemon/eg/runtime/wasi/shell"
 	"github.com/egdaemon/eg/runtime/x/wasi/egbug"
 	"github.com/egdaemon/eg/runtime/x/wasi/eggolang"
+	"github.com/egdaemon/eg/runtime/x/wasi/egrunnermacos"
 )
+
+// Image is the Tart-format OCI image the runner pulls. Cirrus Labs's
+// macos-*-base ships with SSH (admin/admin), Xcode CLI tools, and Homebrew
+// but no dev-language toolchain — the first BuildAndRun step installs the
+// pieces this workload needs via brew.
+const Image = "ghcr.io/cirruslabs/macos-sequoia-xcode:latest"
+
+// Builds the native library and Flutter macOS app inside a pulled macOS guest
+// VM so the host's Homebrew/Xcode state is irrelevant.
+func main() {
+	log.SetFlags(log.Flags() | log.Lshortfile)
+	ctx, done := context.WithTimeout(context.Background(), egenv.TTL())
+	defer done()
+
+	vm := egrunnermacos.New("retrovibed-macos").PullFrom(Image)
+
+	err := eg.Perform(
+		ctx,
+		eg.Build(vm),
+		eg.Module(ctx, vm.ToModuleRunner(), BuildAndRun),
+	)
+
+	if err != nil {
+		log.Fatalln(err)
+	}
+}
+
+// BuildAndRun executes inside the guest. The transpiler lifts this into the
+// generated sub-module's main; only top-level identifiers reachable from this
+// file survive, so the runtime setup lives here rather than in main().
+func BuildAndRun(ctx context.Context, _ eg.Op) error {
+	runtime := shell.Runtime().
+		EnvironFrom(eggolang.Env()...).
+		Environ("PUB_CACHE", egenv.CacheDirectory(".eg", "dart"))
+	flutter := runtime.Directory(egenv.WorkingDirectory("console"))
+
+	return eg.Perform(
+		ctx,
+		eg.Sequential(
+			shell.Op(
+				runtime.New("brew install go duckdb gpgme llvm flutter ffmpeg@7 cocoapods").Timeout(20*time.Minute),
+			),
+			egbug.DebugFailure(
+				shell.Op(
+					flutter.New("mkdir -p build/nativelib"),
+					flutter.New("go -C retrovibedbind build -buildmode=c-shared --tags localdev -o ../build/nativelib/libretrovibed.dylib ./...").Timeout(5*time.Minute),
+				),
+				eg.Sequential(
+					egbug.Log("failed to build native library"),
+					Debug(runtime),
+				),
+			),
+			egbug.DebugFailure(
+				shell.Op(
+					flutter.New(retry(`dart run ffigen --config ffigen.yaml --compiler-opts "-I$(clang --print-resource-dir)/include"`)),
+				),
+				eg.Sequential(
+					egbug.Log("failed to generate ffi bindings"),
+					Debug(runtime),
+				),
+			),
+			shell.Op(
+				flutter.New(retry(`flutter pub get`)),
+				flutter.New(retry(`flutter build macos --debug --dart-define=EG_VM=true`)),
+				flutter.New("cp build/nativelib/libretrovibed.dylib build/macos/Build/Products/Debug/retrovibed.app/Contents/MacOS/libretrovibed.dylib"),
+				flutter.New("codesign --force --sign - build/macos/Build/Products/Debug/retrovibed.app"),
+			),
+			console.RunDevAt(
+				"flutter run -d macos --use-application-binary=build/macos/Build/Products/Debug/retrovibed.app",
+				"$(route -n get default | awk '/gateway:/{print $2}')",
+			),
+		),
+	)
+}
+
+// retry wraps a shell command in a bounded retry loop. Tart's virtio-fs share
+// occasionally returns ENOENT/EIO under load (pubspec.yaml briefly missing,
+// hooks_runner stdout EIO); a fresh syscall after a short sleep usually
+// succeeds.
+func retry(cmd string) string {
+	return `for i in 1 2 3; do ` + cmd + ` && exit 0; sleep 2; done; exit 1`
+}
 
 func Debug(runtime shell.Command) eg.OpFn {
 	return shell.Op(
@@ -21,57 +104,4 @@ func Debug(runtime shell.Command) eg.OpFn {
 		runtime.New("ls -la /Library/Developer/CommandLineTools/usr/lib/clang/").Lenient(true),
 		runtime.New("xcode-select -p"),
 	)
-}
-
-// Baremetal command for macOS local development.
-// Sets up the native library and ffigen bindings so flutter can run locally.
-func main() {
-	log.SetFlags(log.Flags() | log.Lshortfile)
-	ctx, done := context.WithTimeout(context.Background(), egenv.TTL())
-	defer done()
-
-	runtime := shell.Runtime().
-		EnvironFrom(eggolang.Env()...).
-		Environ("PUB_CACHE", egenv.CacheDirectory(".eg", "dart"))
-
-	flutter := runtime.Directory(egenv.WorkingDirectory("console"))
-
-	err := eg.Perform(
-		ctx,
-		eg.Sequential(
-			shell.Op(
-				shell.New("brew install go duckdb gpgme flutter ffmpeg@7 cocoapods"),
-			),
-			egbug.DebugFailure(
-				shell.Op(
-					flutter.New("mkdir -p build/nativelib"),
-					flutter.New("go -C retrovibedbind build -buildmode=c-shared --tags localdev -o ../build/nativelib/retrovibed.dylib ./...").Timeout(5*time.Minute),
-				),
-				eg.Sequential(
-					egbug.Log("failed to build native library"),
-					Debug(runtime),
-				),
-			),
-			egbug.DebugFailure(
-				shell.Op(
-					flutter.New("dart run ffigen --config ffigen.yaml --compiler-opts \"-I$(clang --print-resource-dir)/include\""),
-				),
-				eg.Sequential(
-					egbug.Log("failed to generate ffi bindings"),
-					Debug(runtime),
-				),
-			),
-			shell.Op(
-				flutter.New("flutter pub get"),
-				flutter.New("flutter build macos --debug"),
-				flutter.New("cp build/nativelib/retrovibed.dylib build/macos/Build/Products/Debug/retrovibed.app/Contents/MacOS/retrovibed.dylib"),
-				flutter.New("codesign --force --sign - build/macos/Build/Products/Debug/retrovibed.app"),
-			),
-			console.RunDev("flutter run -d macos --use-application-binary=build/macos/Build/Products/Debug/retrovibed.app"),
-		),
-	)
-
-	if err != nil {
-		log.Fatalln(err)
-	}
 }

--- a/console/lib/httpx.dart
+++ b/console/lib/httpx.dart
@@ -16,8 +16,8 @@ String host() {
 
 String? normalizeuri(String? s) {
   if (s == null) return s;
-  final uri = Uri.parse(s);
-  if (uri.host.isEmpty) return s;
+  final uri = Uri.tryParse(s);
+  if (uri == null || uri.host.isEmpty) return s;
   return "${uri.host}:${uri.port}";
 }
 

--- a/console/lib/media/player.dart
+++ b/console/lib/media/player.dart
@@ -31,7 +31,13 @@ class _VideoState extends State<VideoScreen> {
   late final StreamSubscription<Tracks> sub0;
   late final StreamSubscription<bool> sub1;
 
-  _VideoState(Player player) : controller = VideoController(player);
+  _VideoState(Player player)
+    : controller = VideoController(
+        player,
+        configuration: const bool.fromEnvironment('EG_VM')
+            ? const VideoControllerConfiguration(enableHardwareAcceleration: false)
+            : const VideoControllerConfiguration(),
+      );
 
   void setState(VoidCallback fn) {
     if (!mounted) return;

--- a/console/lib/retrovibed.dart
+++ b/console/lib/retrovibed.dart
@@ -13,7 +13,7 @@ String _frameworksLib(String name) {
 
 File _defaultlib() {
   if (Platform.isMacOS) {
-    return File(_frameworksLib("retrovibed.dylib"));
+    return File(_frameworksLib("libretrovibed.dylib"));
   }
 
   return File("/app/lib/libretrovibed.so");
@@ -31,8 +31,8 @@ String _path() {
   final files = () {
     if (Platform.isMacOS) {
       return [
-        File(_frameworksLib("retrovibed.dylib")),
-        File("build/nativelib/retrovibed.dylib"),
+        File(_frameworksLib("libretrovibed.dylib")),
+        File("build/nativelib/libretrovibed.dylib"),
       ];
     }
 


### PR DESCRIPTION
Wires .eg/dev/console/macos up to dispatch inside a Tart-backed macOS guest via eg's egrunnermacos package. The workload now brew-bootstraps go, llvm, flutter, ffmpeg, gpgme, duckdb, cocoapods; builds the native lib; runs ffigen, pub get, and flutter build under a short retry loop to ride out the working-share's occasional virtio-fs ENOENT/EIO; then launches flutter run via console.RunDevAt pointed at the guest's default-route gateway (the host's softnet bridge, resolved inside the guest at exec time).

.eg/console/console.go grows RunDevAt(cmd, host). RunDev keeps its existing localhost defaults so ios/linux/android dev paths are unchanged; only the macOS VM path overrides the host.

console/lib/retrovibed.dart renames the macOS dylib lookups from retrovibed.dylib to libretrovibed.dylib. The Linux build already emits libretrovibed.so and iOS emits libretrovibed.a; aligning macOS lets ffigen point at one libretrovibed.h entry across platforms.

console/lib/media/player.dart wraps VideoController with an EG_VM-gated configuration that disables hardware acceleration. media_kit_video's macOS path requests kCGLPFAAccelerated in CGLChoosePixelFormat; Apple's paravirtualized graphics in macOS guests cannot satisfy that attribute, CGL returns nil, and the plugin force-unwraps. The EG_VM compile-time define routes through the Metal-only fallback; non-VM builds keep the default.

console/lib/httpx.dart swaps Uri.parse for Uri.tryParse in normalizeuri. Uri.parse throws on a bare ip:port like 192.168.2.1:8081 because the parser treats 192 as a URI scheme and rejects the leading digit; tryParse returns null, and normalizeuri already handles that via uri.host.isEmpty. localhost:8081 and https://api... still resolve identically.

.eg/go.mod's local replace pointing at a checkout of egdaemon/eg with egrunnermacos is intentionally left uncommitted; the workload only builds against eg PR #233 or a later tagged release.