### PR TITLE
enable ffmpeg acoustic indexing on the linux daemon

### DIFF
--- a/.eg/Containerfile
+++ b/.eg/Containerfile
@@ -15,7 +15,7 @@ RUN echo "cache buster 059a9a06-1686-4f49-9a7f-a30535886d54"
 RUN apt-get update && apt-get -y install golang-1.26 egworkload duckdb podman netavark rsync vim dput devscripts dh-make dput uidmap dbus-user-session git unzip xz-utils zip libglu1-mesa clang lld cmake git ninja-build pkg-config libgtk-3-dev liblzma-dev libstdc++-12-dev
 RUN sh /usr/share/eg/install/github.sh > /dev/null
 RUN echo "cache buster 059a9a06-1686-4f49-9a7f-a30535886d50"
-RUN apt-get update && apt-get -y install snapd protobuf-compiler pkgconf clang-19 gh tree flatpak-builder libmpv-dev
+RUN apt-get update && apt-get -y install snapd protobuf-compiler pkgconf clang-19 gh tree flatpak-builder libmpv-dev libavcodec-dev libavformat-dev libavutil-dev libswresample-dev libavfilter-dev libavdevice-dev libswscale-dev
 
 RUN ln -s /usr/lib/go-1.26/bin/go /usr/local/bin/go
 

--- a/.eg/debian/.debskel/Containerfile
+++ b/.eg/debian/.debskel/Containerfile
@@ -9,6 +9,6 @@ RUN add-apt-repository -n ppa:egdaemon/duckdb
 
 RUN echo "cache buster 059a9a06-1686-4f49-9a7f-a30535886d54"
 RUN apt-get update
-RUN apt-get -y install golang-1.26 egworkload libbtrfs-dev libassuan-dev libc6-dev libdevmapper-dev libglib2.0-dev libgpgme-dev libgpg-error-dev libprotobuf-dev libprotobuf-c-dev libseccomp-dev libselinux1-dev libsystemd-dev
+RUN apt-get -y install golang-1.26 egworkload libbtrfs-dev libassuan-dev libc6-dev libdevmapper-dev libglib2.0-dev libgpgme-dev libgpg-error-dev libprotobuf-dev libprotobuf-c-dev libseccomp-dev libselinux1-dev libsystemd-dev libavcodec-dev libavformat-dev libavutil-dev libswresample-dev libavfilter-dev libavdevice-dev libswscale-dev
 
 RUN ln -s /usr/lib/go-1.26/bin/go /usr/local/bin/go

--- a/.eg/debian/.debskel/debian/rules
+++ b/.eg/debian/.debskel/debian/rules
@@ -22,7 +22,7 @@ override_dh_auto_build:
 	# need to set gocache otherwise it'll error out on launchpad builders
 	cp -R $(CURDIR)/src/.dist/linux/* linux
 	cp $(CURDIR)/src/LICENSE $(CURDIR)/debian/copyright
-	GOPROXY="direct" GOCACHE="$(CURDIR)/.gocache" GOMODCACHE="$(CURDIR)/.gomod" GOBIN="$(CURDIR)/linux/usr/bin" /usr/lib/go-1.26/bin/go build -C src/shallows -mod=vendor -buildmode=pie -tags "duckdb_use_lib" -buildvcs=false -o "$(CURDIR)/linux/usr/bin" ./cmd/retrovibe/...
+	GOPROXY="direct" GOCACHE="$(CURDIR)/.gocache" GOMODCACHE="$(CURDIR)/.gomod" GOBIN="$(CURDIR)/linux/usr/bin" /usr/lib/go-1.26/bin/go build -C src/shallows -mod=vendor -buildmode=pie -tags "duckdb_use_lib,ffmpeg_enabled" -buildvcs=false -o "$(CURDIR)/linux/usr/bin" ./cmd/retrovibe/...
 	# tree $(CURDIR)/linux
 
 override_dh_auto_test:

--- a/.eg/debian/daemon.go
+++ b/.eg/debian/daemon.go
@@ -39,8 +39,8 @@ func init() {
 		egdebuild.Option.Version("0.0.:autopatch:"),
 		egdebuild.Option.Description("media distribution platform", "provides torrenting functionality with builtin media player and cloud storage allowing you to take your content anywhere you go"),
 		egdebuild.Option.Debian(errorsx.Must(fs.Sub(debskel, ".debskel"))),
-		egdebuild.Option.DependsBuild("golang-1.26", "dh-make", "debhelper", "duckdb"),
-		egdebuild.Option.Depends("duckdb"),
+		egdebuild.Option.DependsBuild("golang-1.26", "dh-make", "debhelper", "duckdb", "libavcodec-dev", "libavformat-dev", "libavutil-dev", "libswresample-dev", "libavfilter-dev", "libavdevice-dev", "libswscale-dev"),
+		egdebuild.Option.Depends("duckdb", "ffmpeg"),
 	)
 }
 

--- a/.eg/shallows/shallows.go
+++ b/.eg/shallows/shallows.go
@@ -16,10 +16,10 @@ import (
 )
 
 func testBuildTags() []string {
-	return []string{"duckdb_use_lib"}
+	return []string{"duckdb_use_lib", "ffmpeg_enabled"}
 }
 
-var buildTags = []string{"duckdb_use_lib", "retrovibed", "neural"}
+var buildTags = []string{"duckdb_use_lib", "retrovibed", "neural", "ffmpeg_enabled"}
 
 func rootdir() string {
 	return egenv.WorkingDirectory("shallows")

--- a/shallows/acoustics/decode.go
+++ b/shallows/acoustics/decode.go
@@ -21,9 +21,24 @@ func ProbeDuration(path string) (float64, error) {
 	return reader.Duration().Seconds(), nil
 }
 
-// DecodePCM opens an audio file and decodes each segment to mono float32 at
-// SampleRate Hz. Uses a single ffmpeg.Open + reader.Map, seeking between segments.
+// DecodePCM decodes each segment of an audio file to mono float32 at SampleRate.
+// The file is reopened per segment: go-media flushes the decoder at the end of
+// every decode and exposes no way to reset it, so a reader cannot be reused
+// across seeks.
 func DecodePCM(ctx context.Context, path string, segments []Segment) ([][]float32, error) {
+	results := make([][]float32, len(segments))
+	for i, seg := range segments {
+		buf, err := decodeSegment(ctx, path, seg)
+		if err != nil {
+			returnPCMBuffers(results[:i])
+			return nil, err
+		}
+		results[i] = buf
+	}
+	return results, nil
+}
+
+func decodeSegment(ctx context.Context, path string, seg Segment) ([]float32, error) {
 	reader, err := ffmpeg.Open(path)
 	if err != nil {
 		return nil, err
@@ -51,39 +66,27 @@ func DecodePCM(ctx context.Context, path string, segments []Segment) ([][]float3
 	}
 	defer decoders.Close()
 
-	var (
-		buf   []float32
-		endTs float64
-	)
-
-	results := make([][]float32, len(segments))
-	for i, seg := range segments {
-		err = reader.Seek(best, seg.OffsetSec)
-		if err != nil {
-			return nil, err
-		}
-
-		buf = pcmPool.Get().([]float32)[:0]
-		endTs = seg.OffsetSec + seg.DurationSec
-
-		err = reader.DecodeWithContext(ctx, decoders, func(_ int, frame *ffmpeg.Frame) error {
-			if frame.Type() != media.AUDIO {
-				return nil
-			}
-			if ts := frame.Ts(); ts != ffmpeg.TS_UNDEFINED && ts >= endTs {
-				return io.EOF
-			}
-			buf = append(buf, frame.Float32(0)...)
-			return nil
-		})
-
-		if errorsx.Ignore(err, io.EOF) != nil {
-			pcmPool.Put(buf[:0]) // nolint: staticcheck
-			return nil, err
-		}
-
-		results[i] = buf
+	if err = reader.Seek(best, seg.OffsetSec); err != nil {
+		return nil, err
 	}
 
-	return results, nil
+	buf := pcmPool.Get().([]float32)[:0]
+	endTs := seg.OffsetSec + seg.DurationSec
+
+	err = reader.DecodeWithContext(ctx, decoders, func(_ int, frame *ffmpeg.Frame) error {
+		if frame.Type() != media.AUDIO {
+			return nil
+		}
+		if ts := frame.Ts(); ts != ffmpeg.TS_UNDEFINED && ts >= endTs {
+			return io.EOF
+		}
+		buf = append(buf, frame.Float32(0)...)
+		return nil
+	})
+	if err != nil {
+		pcmPool.Put(buf[:0]) // nolint: staticcheck
+		return nil, err
+	}
+
+	return buf, nil
 }

--- a/shallows/acoustics/decode_test.go
+++ b/shallows/acoustics/decode_test.go
@@ -1,0 +1,139 @@
+//go:build !darwin && ffmpeg_enabled
+
+package acoustics
+
+import (
+	"context"
+	"encoding/binary"
+	"math"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// writeWAV synthesizes a mono 16-bit PCM WAV sine wave at the requested rate and
+// duration, writes it to a temp file, and returns the path. FFmpeg decodes the
+// canonical WAV layout natively, which lets these tests exercise the real
+// decoder without committing a binary fixture.
+func writeWAV(t *testing.T, sampleRate int, durationSec, freq float64) string {
+	t.Helper()
+
+	n := int(float64(sampleRate) * durationSec)
+	dataSize := n * 2
+
+	le := binary.LittleEndian
+	b := make([]byte, 0, 44+dataSize)
+	b = append(b, "RIFF"...)
+	b = le.AppendUint32(b, uint32(36+dataSize))
+	b = append(b, "WAVE"...)
+	b = append(b, "fmt "...)
+	b = le.AppendUint32(b, 16)                   // fmt chunk size
+	b = le.AppendUint16(b, 1)                    // PCM
+	b = le.AppendUint16(b, 1)                    // mono
+	b = le.AppendUint32(b, uint32(sampleRate))   // sample rate
+	b = le.AppendUint32(b, uint32(sampleRate*2)) // byte rate
+	b = le.AppendUint16(b, 2)                    // block align
+	b = le.AppendUint16(b, 16)                   // bits per sample
+	b = append(b, "data"...)
+	b = le.AppendUint32(b, uint32(dataSize))
+	for i := range n {
+		s := math.Sin(2.0 * math.Pi * freq * float64(i) / float64(sampleRate))
+		b = le.AppendUint16(b, uint16(int16(s*32767)))
+	}
+
+	path := filepath.Join(t.TempDir(), "tone.wav")
+	if err := os.WriteFile(path, b, 0o600); err != nil {
+		t.Fatalf("write wav: %v", err)
+	}
+	return path
+}
+
+func TestProbeDuration(t *testing.T) {
+	t.Run("returns the duration of a valid file", func(t *testing.T) {
+		dur, err := ProbeDuration(writeWAV(t, 44100, 12.0, 440))
+		if err != nil {
+			t.Fatalf("ProbeDuration: %v", err)
+		}
+		if dur < 11.0 || dur > 13.0 {
+			t.Fatalf("duration %.3fs, expected ~12s", dur)
+		}
+	})
+
+	t.Run("errors on a missing file", func(t *testing.T) {
+		if _, err := ProbeDuration(filepath.Join(t.TempDir(), "missing.wav")); err == nil {
+			t.Fatal("expected error for missing file")
+		}
+	})
+}
+
+func TestDecodePCM(t *testing.T) {
+	t.Run("decodes every segment to mono float32 at SampleRate", func(t *testing.T) {
+		segments := SegmentsForDuration(12.0)
+
+		pcm, err := DecodePCM(context.Background(), writeWAV(t, 44100, 12.0, 440), segments)
+		if err != nil {
+			t.Fatalf("DecodePCM: %v", err)
+		}
+		defer returnPCMBuffers(pcm)
+
+		if len(pcm) != NumSegments {
+			t.Fatalf("got %d segments, expected %d", len(pcm), NumSegments)
+		}
+
+		expected := int(segments[0].DurationSec * SampleRate)
+		for i, seg := range pcm {
+			if len(seg) < expected/2 || len(seg) > expected*2 {
+				t.Fatalf("segment %d: %d samples, expected ~%d at %dHz", i, len(seg), expected, SampleRate)
+			}
+			for _, v := range seg {
+				// resampling overshoots the source's [-1, 1] slightly; this only
+				// guards against garbage, not exact normalization.
+				if v < -1.5 || v > 1.5 {
+					t.Fatalf("segment %d: sample %f far outside audio range", i, v)
+				}
+			}
+		}
+	})
+
+	t.Run("errors on a missing file", func(t *testing.T) {
+		_, err := DecodePCM(context.Background(), filepath.Join(t.TempDir(), "missing.wav"), SegmentsForDuration(12.0))
+		if err == nil {
+			t.Fatal("expected error for missing file")
+		}
+	})
+
+	t.Run("errors on a non-media file", func(t *testing.T) {
+		path := filepath.Join(t.TempDir(), "notaudio.txt")
+		if err := os.WriteFile(path, []byte("this is not media"), 0o600); err != nil {
+			t.Fatalf("write file: %v", err)
+		}
+		if _, err := DecodePCM(context.Background(), path, SegmentsForDuration(12.0)); err == nil {
+			t.Fatal("expected error for non-media file")
+		}
+	})
+}
+
+func TestAnalyzeFile(t *testing.T) {
+	t.Run("produces a non-zero vector from a real file", func(t *testing.T) {
+		fv, err := AnalyzeFile(context.Background(), writeWAV(t, 44100, 12.0, 440))
+		if err != nil {
+			t.Fatalf("AnalyzeFile: %v", err)
+		}
+
+		nonZero := 0
+		for _, v := range fv {
+			if v != 0 {
+				nonZero++
+			}
+		}
+		if nonZero == 0 {
+			t.Fatal("expected a non-zero feature vector")
+		}
+	})
+
+	t.Run("rejects a track shorter than the minimum", func(t *testing.T) {
+		if _, err := AnalyzeFile(context.Background(), writeWAV(t, 44100, 5.0, 440)); err == nil {
+			t.Fatal("expected error for sub-minimum track")
+		}
+	})
+}


### PR DESCRIPTION
The daemon was built with `duckdb_use_lib` only, so acoustics resolved to the decode stub and logged "duration detection failed: unsupported operation" for every track — indexing never ran. ffmpeg is a stock apt dependency on linux, so turn `ffmpeg_enabled` on for the builds that run the indexer (the .deb daemon plus the eg compile/test step) and leave darwin/mobile on the stub: those query a daemon that already has the data rather than decoding the library locally.

DecodePCM reused one decoder across all three segments via Seek, but go-media flushes the decoder at the end of every decode and exposes no way to reset it, so every segment after the first failed with AVCodec_send_packet:EOF. Reopen per segment.

The ffmpeg-tagged probe/decode/analyze tests run in CI now that testBuildTags carries the tag, so the linux ffmpeg build is gated instead of assumed.