### PR TITLE
shorten quota usage titles and mark consumed value as used

### DIFF
--- a/console/lib/quotas/card.dart
+++ b/console/lib/quotas/card.dart
@@ -60,10 +60,11 @@ class _CardState extends State<Card> {
             mainAxisAlignment: MainAxisAlignment.spaceBetween,
             crossAxisAlignment: CrossAxisAlignment.start,
             children: [
-              _typography.Typography.future(_storageFuture, defaults: Storage),
+              _typography.Typography.future(_storageFuture, defaults: Storage, label: "Storage"),
               _typography.Typography.future(
                 _bandwidthFuture,
                 defaults: Bandwidth,
+                label: "Bandwidth",
               ),
             ],
           ),

--- a/console/lib/quotas/card.dart
+++ b/console/lib/quotas/card.dart
@@ -27,18 +27,18 @@ class _CardState extends State<Card> {
   void initState() {
     super.initState();
     _storageFuture = httpx.withRetry(
-      () => quotas.api.get(Storage.sku, options: [authn.Authenticated.bearer(context)]).then((v) => v.quota).catchError(
-        (cause) {
-          return Storage;
-        },
-        test: httpx.ErrorsTest.err404,
-      ),
+      () => quotas.api
+          .get(Storage.sku, options: [authn.Authenticated.bearer(context)])
+          .then((v) => v.quota..description = Storage.description)
+          .catchError((cause) {
+            return Storage;
+          }, test: httpx.ErrorsTest.err404),
     );
 
     _bandwidthFuture = httpx.withRetry(
       () => quotas.api
           .get(Bandwidth.sku, options: [authn.Authenticated.bearer(context)])
-          .then((v) => v.quota)
+          .then((v) => v.quota..description = Bandwidth.description)
           .catchError((cause) {
             return Bandwidth;
           }, test: httpx.ErrorsTest.err404),
@@ -60,11 +60,10 @@ class _CardState extends State<Card> {
             mainAxisAlignment: MainAxisAlignment.spaceBetween,
             crossAxisAlignment: CrossAxisAlignment.start,
             children: [
-              _typography.Typography.future(_storageFuture, defaults: Storage, label: "Storage"),
+              _typography.Typography.future(_storageFuture, defaults: Storage),
               _typography.Typography.future(
                 _bandwidthFuture,
                 defaults: Bandwidth,
-                label: "Bandwidth",
               ),
             ],
           ),

--- a/console/lib/quotas/sku.dart
+++ b/console/lib/quotas/sku.dart
@@ -2,13 +2,13 @@ import './api.dart' as api;
 
 final Storage = api.Quota(
   sku: "59790d9e-9c74-152c-fceb-a26607f02146",
-  description: "storage usage",
+  description: "Storage",
   adjustable: true,
 );
 
 final Bandwidth = api.Quota(
   sku: "620cac69-da27-2e19-ae99-d162275e528d",
-  description: "bandwidth usage",
+  description: "Bandwidth",
   adjustable: true,
 );
 

--- a/console/lib/quotas/typography.dart
+++ b/console/lib/quotas/typography.dart
@@ -6,17 +6,19 @@ import './usage.dart';
 class Typography extends StatelessWidget {
   static api.Quota zero = api.Quota();
   final api.Quota current;
+  final String label;
   final Future<api.Quota> Function(api.Quota)? onChange;
-  const Typography(this.current, {super.key, this.onChange});
+  const Typography(this.current, {super.key, this.label = "", this.onChange});
 
   static FutureBuilder<api.Quota> future(
     Future<api.Quota> pending, {
     Future<api.Quota> Function(api.Quota)? onChange,
     api.Quota? defaults,
+    String label = "",
   }) {
     return ds.future(defaults ?? Typography.zero, pending, (snapshot) {
       return ds.ErrorScreen(
-        Typography(snapshot.data ?? Typography.zero, key: ValueKey(snapshot.data?.updatedAt), onChange: onChange),
+        Typography(snapshot.data ?? Typography.zero, key: ValueKey(snapshot.data?.updatedAt), label: label, onChange: onChange),
         cause: snapshot.hasError ? ds.Error.unknown(snapshot.error!) : ds.Error.zero,
       );
     });
@@ -25,15 +27,16 @@ class Typography extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final defaults = ds.Defaults.of(context);
+    final title = label.isEmpty ? current.description : label;
     final typography =
-        "${ds.bytesx(current.consumed.toInt()).toIEC600272Format()} of ${ds.bytesx(current.available().toInt()).toIEC600272Format()}";
+        "${ds.bytesx(current.consumed.toInt()).toIEC600272Format()} used of ${ds.bytesx(current.available().toInt()).toIEC600272Format()}";
 
     return Column(
       mainAxisSize: MainAxisSize.min,
       mainAxisAlignment: MainAxisAlignment.start,
       crossAxisAlignment: CrossAxisAlignment.start,
       spacing: defaults.spacing / 2,
-      children: [Text(current.description), Usage(current), Text(typography)],
+      children: [Text(title), Usage(current), Text(typography)],
     );
   }
 }

--- a/console/lib/quotas/typography.dart
+++ b/console/lib/quotas/typography.dart
@@ -6,19 +6,17 @@ import './usage.dart';
 class Typography extends StatelessWidget {
   static api.Quota zero = api.Quota();
   final api.Quota current;
-  final String label;
   final Future<api.Quota> Function(api.Quota)? onChange;
-  const Typography(this.current, {super.key, this.label = "", this.onChange});
+  const Typography(this.current, {super.key, this.onChange});
 
   static FutureBuilder<api.Quota> future(
     Future<api.Quota> pending, {
     Future<api.Quota> Function(api.Quota)? onChange,
     api.Quota? defaults,
-    String label = "",
   }) {
     return ds.future(defaults ?? Typography.zero, pending, (snapshot) {
       return ds.ErrorScreen(
-        Typography(snapshot.data ?? Typography.zero, key: ValueKey(snapshot.data?.updatedAt), label: label, onChange: onChange),
+        Typography(snapshot.data ?? Typography.zero, key: ValueKey(snapshot.data?.updatedAt), onChange: onChange),
         cause: snapshot.hasError ? ds.Error.unknown(snapshot.error!) : ds.Error.zero,
       );
     });
@@ -27,7 +25,6 @@ class Typography extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final defaults = ds.Defaults.of(context);
-    final title = label.isEmpty ? current.description : label;
     final typography =
         "${ds.bytesx(current.consumed.toInt()).toIEC600272Format()} used of ${ds.bytesx(current.available().toInt()).toIEC600272Format()}";
 
@@ -36,7 +33,7 @@ class Typography extends StatelessWidget {
       mainAxisAlignment: MainAxisAlignment.start,
       crossAxisAlignment: CrossAxisAlignment.start,
       spacing: defaults.spacing / 2,
-      children: [Text(title), Usage(current), Text(typography)],
+      children: [Text(current.description), Usage(current), Text(typography)],
     );
   }
 }


### PR DESCRIPTION
"amount of storage available" reads as remaining capacity, leading users to believe the first value is what is left rather than what is consumed; the same ambiguity applies to bandwidth. Use short "Storage"/"Bandwidth" titles and append "used" after the consumed value so the gauge reads unambiguously.