### PR TITLE
Fixes for appimage builder updating to ubuntu resolute.

### DIFF
--- a/.dist/AppImageBuilder.yml
+++ b/.dist/AppImageBuilder.yml
@@ -1,3 +1,38 @@
+# Resolute has a number of third party bugs we've worked around:
+#
+# THIRD PARTY BUG: appimage-builder throws APPRUN_ERROR (ENOENT) on launch.
+# appimage-builder installs the dynamic linker into runtime/compat/usr/lib64/ but
+# fails to generate the root-level lib64 symlink the AppRun runtime expects to
+# find it at. Fixed below via after_runtime, which creates the missing symlink
+# once runtime/compat/ has been populated but before the AppDir is packaged.
+#
+# THIRD PARTY BUG: libass crashes with "undefined symbol: FcConfigSetDefaultSubstitute"
+# on launch. libass is pulled in transitively via ffmpeg8/libavfilter, and needs a
+# fontconfig new enough to export FcConfigSetDefaultSubstitute (fontconfig >= 2.17).
+# appimage-builder excludes fontconfig from the bundle by default, leaving it to
+# resolve against whatever fontconfig the host has, which is commonly older than
+# that. We bundle libfontconfig1/fontconfig-config explicitly from the same apt
+# snapshot libass comes from -- we don't want to rely on host libraries when we
+# can avoid it.
+#
+# THIRD PARTY BUG: GTK aborts with a core dump the first time it needs to render a
+# fallback icon (Gtk:ERROR ... ensure_surface_for_gicon ... Could not spawn
+# ".../glycin-loaders/2+/glycin-svg" ... No such file or directory). GTK's
+# icon-theme rendering routes SVG loading through glycin, a sandboxed helper
+# spawned via a hardcoded absolute path (e.g. /usr/libexec/glycin-loaders/2+/glycin-svg)
+# baked in at compile time. AppImage's mount doesn't remap /usr the way Flatpak's
+# sandbox does, so that lookup always hits the real host filesystem instead of the
+# bundle, and fails on hosts that don't have glycin installed at that exact path
+# (or at all). appimage-builder's own runtime setup requires app_info.exec to be a
+# real ELF binary (it errors out with "Main executable is not an elf executable"
+# otherwise), so we can't point it at a wrapper script directly. Fixed instead via
+# after_runtime, which renames the real binary to retrovibed.bin once
+# appimage-builder's own setup has finished with it, and puts a wrapper script in
+# its place at the original path: it relaunches retrovibed.bin under bubblewrap
+# (bundled, see apt.include) with a synthetic /usr grafting in the bundle's own
+# glycin-loaders. See .dist/linux/usr/lib/retrovibed/appimage-launcher.sh for the
+# full explanation.
+
 version: 1
 
 AppDir:
@@ -11,26 +46,24 @@ AppDir:
     exec: usr/lib/retrovibed/retrovibed
     exec_args: $@
 
-  # stuck on questing because resolute causes the following issues:
-  # Finding 1: Fix APPRUN_ERROR (ENOENT) caused by missing lib64 layout in resolute (t64)
-  # appimage-builder installs the dynamic linker into runtime/compat/usr/lib64/ but
-  # fails to generate the root-level symlink directory expected by the AppRun runtime.
-  # Required manual fix in pipeline before packaging:
-  #   mkdir -p ${APPDIR}/runtime/compat/lib64
-  #   ln -s ../usr/lib64/ld-linux-x86-64.so.2 ${APPDIR}/runtime/compat/lib64/ld-linux-x86-64.so.2
-  # Finding 2: Prevent GTK/Glycin core dump during SVG fallback icon rendering
-  # Glycin spawns decoders via 'env -i', stripping APPDIR/PATH and causing execution
-  # to look for /usr/libexec/glycin-loaders/2+/glycin-svg on the host filesystem.
+  after_runtime: |
+    mkdir -p "${APPDIR}/runtime/compat/lib64"
+    ln -sf ../usr/lib64/ld-linux-x86-64.so.2 "${APPDIR}/runtime/compat/lib64/ld-linux-x86-64.so.2"
+
+    # switch the binary with the appimage launcher script.
+    mv "${APPDIR}/usr/lib/retrovibed/retrovibed" "${APPDIR}/usr/lib/retrovibed/retrovibed.bin"
+    mv "${APPDIR}/usr/lib/retrovibed/appimage-launcher.sh" "${APPDIR}/usr/lib/retrovibed/retrovibed"
+
   apt:
     arch: !ENV "${APT_ARCH}"
     sources:
-      - sourceline: "deb https://archive.ubuntu.com/ubuntu/ questing main restricted universe multiverse"
+      - sourceline: "deb https://archive.ubuntu.com/ubuntu/ resolute main restricted universe multiverse"
         key_url: "https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x871920D1991BC93C"
-      - sourceline: "deb https://archive.ubuntu.com/ubuntu/ questing-updates main restricted universe multiverse"
+      - sourceline: "deb https://archive.ubuntu.com/ubuntu/ resolute-updates main restricted universe multiverse"
         key_url: "https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x871920D1991BC93C"
-      - sourceline: "deb https://archive.ubuntu.com/ubuntu/ questing-backports main restricted universe multiverse"
+      - sourceline: "deb https://archive.ubuntu.com/ubuntu/ resolute-backports main restricted universe multiverse"
         key_url: "https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x871920D1991BC93C"
-      - sourceline: "deb http://security.ubuntu.com/ubuntu questing-security main restricted universe multiverse"
+      - sourceline: "deb http://security.ubuntu.com/ubuntu resolute-security main restricted universe multiverse"
         key_url: "https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x871920D1991BC93C"
     include:
       - libgtk-3-0t64
@@ -39,14 +72,16 @@ AppDir:
       - dash
       - bash
       - perl
-    exclude:
-      - libglib2.0-data
-      - shared-mime-info
-      - xdg-user-dirs
+      - libfontconfig1
+      - fontconfig-config
       - humanity-icon-theme
       - hicolor-icon-theme
       - adwaita-icon-theme
       - ubuntu-mono
+      - bubblewrap
+    exclude:
+      - libglib2.0-data
+
   files:
     exclude:
       - usr/share/man

--- a/.dist/linux/usr/lib/retrovibed/appimage-launcher.sh
+++ b/.dist/linux/usr/lib/retrovibed/appimage-launcher.sh
@@ -1,0 +1,35 @@
+#!/bin/sh
+# Launches the real retrovibed binary (retrovibed.bin, renamed from retrovibed by
+# AppImageBuilder.yml's after_runtime hook) under bubblewrap when available. This
+# script is installed in retrovibed's place at usr/lib/retrovibed/retrovibed by
+# that same hook -- app_info.exec has to point at the real ELF binary for
+# appimage-builder's own runtime setup to work, so the swap happens afterward.
+#
+# Why: GTK's icon-theme rendering routes SVG loading through glycin, a sandboxed
+# helper spawned via a hardcoded absolute path (e.g.
+# /usr/libexec/glycin-loaders/2+/glycin-svg) baked in at compile time. AppImage's
+# mount doesn't remap /usr the way Flatpak's sandbox does, so that absolute lookup
+# always hits the real host filesystem, which usually doesn't have glycin at that
+# exact path (or at all) -- causing a hard abort the first time GTK needs any
+# fallback icon.
+#
+# Fix: relaunch under bwrap with a synthetic /usr: every real top-level entry is
+# rebound in read-only, except usr/libexec/glycin-loaders, which is grafted in
+# from the bundle. bwrap is what Ubuntu's AppArmor unprivileged-userns hardening
+# already trusts for this (Flatpak itself relies on it), unlike a raw
+# unshare/mount --bind. bwrap itself is bundled (see apt.include in
+# AppImageBuilder.yml), so this doesn't depend on the host having it installed.
+HERE="$APPDIR"
+REAL="$HERE/usr/lib/retrovibed/retrovibed.bin"
+BWRAP="$HERE/usr/bin/bwrap"
+
+USR_BINDS=""
+for d in /usr/*/; do
+  name=$(basename "$d")
+  USR_BINDS="$USR_BINDS --ro-bind /usr/$name /usr/$name"
+done
+
+exec "$BWRAP" --dev-bind / / --tmpfs /usr $USR_BINDS \
+  --bind "$HERE/usr/libexec/glycin-loaders" /usr/libexec/glycin-loaders \
+  --chdir "$HERE/runtime/compat" \
+  -- "$REAL" "$@"

--- a/.eg/release/release.go
+++ b/.eg/release/release.go
@@ -15,8 +15,8 @@ import (
 
 func Release(b *tarballs.Build) eg.OpFn {
 	return eggithub.Release(
-		egtarball.Archive(tarballs.Retrovibed(b)),
 		egtarball.Archive(tarballs.RetrovibedSource()),
+		egtarball.Archive(tarballs.Retrovibed(b)),
 		egenv.CacheDirectory(tarballs.Flatpak(b)),
 		egenv.WorkspaceDirectory(tarballs.AppImage(b)),
 		egenv.WorkspaceDirectory(tarballs.AppImageZsync(b)),


### PR DESCRIPTION
- updated build distro from questing to resolute for lts support.
- fixed glycin issues via bubblewrap and a appimage-launcher.sh script.